### PR TITLE
Add live progress feedback for Ingest & Sync operations

### DIFF
--- a/docs/specs/12_progress-feedback-analyse.md
+++ b/docs/specs/12_progress-feedback-analyse.md
@@ -1,0 +1,158 @@
+# Progress-Feedback bei Ingest & Sync — Ist-Stand & Anforderungsanalyse
+
+## 1. Ist-Stand-Analyse
+
+### 1.1 Aktuelle Architektur (Datenfluss)
+
+```
+[Frontend]                [AdminController]              [Services]
+    |                           |                            |
+    |-- POST /admin/ingest ---->|                            |
+    |<-- 202 {status:running} --|                            |
+    |                           |-- CompletableFuture ------>|
+    |                           |   (async, Fire & Forget)   |
+    |-- GET /admin/job/status ->|                            |
+    |<-- {status:running} ------|                            |
+    |    (alle 3s polling)      |                            |
+    |                           |                         [crawl]
+    |                           |                         [chunk]
+    |                           |                         [store]
+    |                           |                            |
+    |-- GET /admin/job/status ->|                            |
+    |<-- {status:completed,  ---|<-- Ergebnis ---------------|
+    |     result:{...}}         |                            |
+```
+
+### 1.2 Aktuelles Feedback an den User
+
+| Zeitpunkt | Was der User sieht | Was tatsächlich passiert |
+|-----------|---------------------|------------------------|
+| Start | Toast: "Ingest gestartet..." | HTTP 202 → Async-Job startet |
+| Während (bis zu Minuten) | Button zeigt "Sync..." (disabled) | Crawling → Chunking → Storing |
+| Ende | Toast mit Endergebnis | JobStatus wechselt auf "completed" |
+
+**Problem:** Zwischen Start und Ende gibt es **keinerlei Fortschrittsanzeige**. Der User sieht nur, dass "etwas läuft", hat aber keine Information über:
+- Wie viele Seiten insgesamt verarbeitet werden müssen
+- Wie viele bereits verarbeitet sind
+- In welcher Phase sich der Prozess befindet (Crawling, Chunking, Storing)
+- Geschätzte verbleibende Zeit
+- Welche Seite gerade verarbeitet wird
+
+### 1.3 Verfügbare Daten in den Services
+
+#### IngestionService.ingestAll()
+| Phase | Verfügbare Information | Aktuell genutzt? |
+|-------|----------------------|------------------|
+| **Crawling** | Seitenanzahl pro Space (nach `client.getPages()`) | Nur Log |
+| **Chunking** | Fortlaufender Zähler `doc[i]` von `documents.size()` | Nein |
+| **Chunking** | Seitenname (`doc.title()`) | Nur im Fehlerfall geloggt |
+| **Storing** | Batch-Fortschritt `[stored/total]` Chunks | Nur Log |
+| **Storing** | Fallback auf Einzel-Insert | Nur Log |
+
+#### SyncService.syncSpace()
+| Phase | Verfügbare Information | Aktuell genutzt? |
+|-------|----------------------|------------------|
+| **Erster Sync** | Delegation an `ingestSpace()` | Nein |
+| **Änderungs-Crawl** | Anzahl geänderter Seiten | Nur Log |
+| **Re-Ingest** | Fortlaufender Zähler pro geänderter Seite | Nein |
+| **Löscherkennung** | Anzahl gelöschter Seiten | Nur Log |
+
+#### CrawlerService.processPages()
+| Phase | Verfügbare Information | Aktuell genutzt? |
+|-------|----------------------|------------------|
+| **Seitenabruf** | `pages.size()` total | Nur Log |
+| **Pro Seite** | `i+1 / pages.size()`, Seitenname | Nur Log |
+| **Pro Seite** | Anzahl Kommentare, Attachments | Nur Log |
+
+### 1.4 Bestehende Infrastruktur
+
+- **JobStatus Record**: `{status, operation, result, error}` — kein Feld für Fortschritt
+- **AtomicReference<JobStatus>**: Wird nur bei Start/Ende/Fehler gesetzt, nie während der Verarbeitung
+- **Polling-Intervall**: 3 Sekunden — grundsätzlich für Progress-Updates geeignet
+- **Frontend**: `pollJobStatus()` prüft nur `completed` oder `failed`, ignoriert Zwischenstatus
+
+---
+
+## 2. Anforderungsanalyse
+
+### 2.1 Funktionale Anforderungen
+
+#### FA-1: Phasen-Anzeige
+Der User muss sehen können, in welcher Phase sich der aktuelle Job befindet:
+- **Crawling** — Seiten werden von Confluence abgerufen
+- **Chunking** — Seiten werden in Chunks aufgeteilt
+- **Storing** — Chunks werden in die Vektordatenbank geschrieben
+- **Deleting** (nur Sync) — Gelöschte Seiten werden entfernt
+
+#### FA-2: Seitenfortschritt
+Während der Verarbeitung muss angezeigt werden:
+- Aktuelle Seite: `"Seite 5 von 42"`
+- Name der aktuell verarbeiteten Seite (optional, für Debugging nützlich)
+
+#### FA-3: Chunk-Fortschritt
+Beim Storing muss angezeigt werden:
+- Chunks gespeichert: `"120 von 380 Chunks gespeichert"`
+
+#### FA-4: Progress Bar
+Eine visuelle Fortschrittsanzeige (Progress Bar) im Admin Panel, die:
+- Den Gesamtfortschritt prozentual anzeigt
+- Die aktuelle Phase textlich beschreibt
+- Sich während des Polling-Zyklus (3s) aktualisiert
+
+#### FA-5: Space-spezifischer Fortschritt
+Bei Multi-Space-Jobs (z.B. "Alle Spaces syncen") soll erkennbar sein, welcher Space gerade verarbeitet wird.
+
+#### FA-6: Fehlerzähler live
+Die Anzahl der Fehler soll schon während der Verarbeitung sichtbar sein, nicht erst im Endergebnis.
+
+### 2.2 Nicht-funktionale Anforderungen
+
+#### NFA-1: Performance
+- Progress-Updates dürfen die Verarbeitung nicht verlangsamen
+- Das Polling-Intervall von 3s ist ausreichend — kein WebSocket nötig
+
+#### NFA-2: Thread-Safety
+- Progress-Updates müssen thread-safe sein (wie bisher `AtomicReference`)
+
+#### NFA-3: Abwärtskompatibilität
+- Bestehende API-Antworten (`IngestionResult`, `SyncResult`) bleiben unverändert
+- Das neue Progress-Feld im `JobStatus` ist additiv (bestehende Clients ignorieren es)
+
+#### NFA-4: Einfachheit
+- Kein WebSocket, keine SSE für Progress — Polling reicht bei 3s Intervall
+- Kein persistenter Progress-State — nur In-Memory während der Jobausführung
+
+### 2.3 Betroffene Komponenten
+
+| Komponente | Änderung | Umfang |
+|-----------|---------|--------|
+| `AdminController.JobStatus` | Neues Feld `progress` | Klein |
+| `IngestionService` | Progress-Callbacks während Crawl/Chunk/Store | Mittel |
+| `SyncService` | Progress-Callbacks während Sync-Phasen | Mittel |
+| `CrawlerService` | Möglichkeit, Fortschritt nach außen zu melden | Mittel |
+| `app.js` (Frontend) | Progress Bar rendern, Polling erweitern | Mittel |
+| `index.html` / `style.css` | Progress Bar Markup/Styling | Klein |
+
+### 2.4 Informationsmodell — Was pro Phase angezeigt wird
+
+```
+Ingest-Job:
+├── Phase: CRAWLING
+│   └── "Space DS: Seite 3/15 — 'Projektübersicht'"
+├── Phase: CHUNKING
+│   └── "Seite 8/42 — 'API-Dokumentation' (156 Chunks bisher)"
+├── Phase: STORING
+│   └── "240/380 Chunks gespeichert (Batch 5/8)"
+└── Ergebnis: 42 Seiten, 380 Chunks, 2 Fehler, 1m 23s
+
+Sync-Job:
+├── Phase: CRAWLING_CHANGES
+│   └── "Space DS: 5 geänderte Seiten gefunden"
+├── Phase: UPDATING
+│   └── "Seite 2/5 — 'Release Notes' (re-indexing)"
+├── Phase: DETECTING_DELETIONS
+│   └── "Prüfe gelöschte Seiten..."
+├── Phase: DELETING
+│   └── "3 Seiten gelöscht"
+└── Ergebnis: 5 aktualisiert, 3 gelöscht, 28 Chunks, 0 Fehler, 15s
+```

--- a/docs/specs/12_progress-feedback-spec.md
+++ b/docs/specs/12_progress-feedback-spec.md
@@ -1,0 +1,385 @@
+# Progress-Feedback bei Ingest & Sync — Technische Spezifikation
+
+> Voraussetzung: [Ist-Stand & Anforderungsanalyse](12_progress-feedback-analyse.md)
+
+## 1. Übersicht
+
+Erweiterung der bestehenden Polling-Architektur um ein `progress`-Feld im `JobStatus`, das bei jedem Poll-Request den aktuellen Fortschritt des laufenden Jobs liefert. Im Frontend wird dieses Feld als Progress Bar mit Phase/Detail-Text dargestellt.
+
+## 2. Backend-Design
+
+### 2.1 Neues Record: `JobProgress`
+
+```java
+// AdminController.java (oder eigene Datei)
+public record JobProgress(
+    String phase,           // CRAWLING, CHUNKING, STORING, UPDATING, DELETING
+    String detail,          // Freitext: "Space DS: Seite 3/15 — 'Projektübersicht'"
+    int currentItem,        // Aktuelle Position (z.B. Seite 3)
+    int totalItems,         // Gesamtzahl (z.B. 15 Seiten)
+    int chunksProcessed,    // Bisher erzeugte/gespeicherte Chunks
+    int errors,             // Bisherige Fehler
+    String currentSpace     // Aktueller Space Key (bei Multi-Space-Jobs)
+) {
+    public int percentComplete() {
+        return totalItems > 0 ? (int) ((currentItem * 100L) / totalItems) : 0;
+    }
+}
+```
+
+### 2.2 Erweiterung: `JobStatus`
+
+```java
+public record JobStatus(
+    String status,       // idle, running, completed, failed
+    String operation,    // ingest, sync, ingest:SPACEKEY, sync:SPACEKEY
+    Object result,       // IngestionResult or SyncResult (nur bei completed)
+    String error,        // Fehlermeldung (nur bei failed)
+    JobProgress progress // NEU: Live-Fortschritt (nur bei running)
+) {}
+```
+
+### 2.3 Progress-Callback-Mechanismus
+
+Statt die Services direkt an den Controller zu koppeln, wird ein einfacher `Consumer<JobProgress>` als Callback verwendet:
+
+```java
+// AdminController — bei Jobstart:
+Consumer<JobProgress> progressCallback = progress ->
+    currentJob.set(new JobStatus("running", operation, null, null, progress));
+```
+
+Die Services erhalten diesen Callback als Parameter:
+
+```java
+// IngestionService
+public IngestionResult ingestAll(Consumer<JobProgress> onProgress) { ... }
+
+// SyncService
+public SyncResult syncAll(Consumer<JobProgress> onProgress) { ... }
+```
+
+**Abwärtskompatibilität:** Die bestehenden parameterlosen Methoden bleiben als Overloads erhalten (z.B. für SyncScheduler):
+
+```java
+public IngestionResult ingestAll() {
+    return ingestAll(p -> {}); // No-op callback
+}
+```
+
+### 2.4 Progress-Updates im IngestionService
+
+```java
+public IngestionResult ingestAll(Consumer<JobProgress> onProgress) {
+    // Phase 1: Crawling
+    onProgress.accept(new JobProgress("CRAWLING", "Crawle Spaces...",
+        0, 0, 0, 0, null));
+
+    List<ConfluenceDocument> documents = crawlerService.crawlAll();
+
+    // Phase 2: Chunking
+    int total = documents.size();
+    for (int i = 0; i < total; i++) {
+        ConfluenceDocument doc = documents.get(i);
+        onProgress.accept(new JobProgress("CHUNKING",
+            String.format("Seite %d/%d — '%s'", i + 1, total, doc.title()),
+            i + 1, total, chunksCreated, errors, doc.spaceKey()));
+        // ... chunk logic ...
+    }
+
+    // Phase 3: Storing
+    // storeBatched() bekommt ebenfalls den Callback
+    chunksStored = storeBatched(allChunks, onProgress, total);
+
+    return new IngestionResult(...);
+}
+```
+
+Storing-Progress innerhalb `storeBatched()`:
+
+```java
+private int storeBatched(List<Document> chunks,
+                         Consumer<JobProgress> onProgress, int totalPages) {
+    int stored = 0;
+    for (int i = 0; i < chunks.size(); i += batchSize) {
+        // ... batch logic ...
+        stored += batch.size();
+        onProgress.accept(new JobProgress("STORING",
+            String.format("%d/%d Chunks gespeichert", stored, chunks.size()),
+            stored, chunks.size(), stored, errors, null));
+    }
+    return stored;
+}
+```
+
+### 2.5 Progress-Updates im SyncService
+
+```java
+public SyncResult syncAll(Consumer<JobProgress> onProgress) {
+    for (int s = 0; s < spaces.size(); s++) {
+        String spaceKey = spaces.get(s);
+        onProgress.accept(new JobProgress("CRAWLING_CHANGES",
+            String.format("Space %s (%d/%d)", spaceKey, s + 1, spaces.size()),
+            s + 1, spaces.size(), 0, 0, spaceKey));
+
+        SyncResult result = syncSpace(spaceKey, onProgress);
+        // ... aggregate results ...
+    }
+}
+
+public SyncResult syncSpace(String spaceKey, Consumer<JobProgress> onProgress) {
+    // Bei erstem Sync → delegiert an ingestSpace(spaceKey, onProgress)
+
+    // Inkrementeller Sync:
+    // Phase: CRAWLING_CHANGES
+    List<ConfluenceDocument> changedDocs = crawlerService.crawlChangesSince(...);
+    onProgress.accept(new JobProgress("CRAWLING_CHANGES",
+        String.format("Space %s: %d geänderte Seiten", spaceKey, changedDocs.size()),
+        0, changedDocs.size(), 0, errors, spaceKey));
+
+    // Phase: UPDATING (pro geänderter Seite)
+    for (int i = 0; i < changedDocs.size(); i++) {
+        onProgress.accept(new JobProgress("UPDATING",
+            String.format("Seite %d/%d — '%s'", i + 1, changedDocs.size(), doc.title()),
+            i + 1, changedDocs.size(), chunksCreated, errors, spaceKey));
+        // ... update logic ...
+    }
+
+    // Phase: DETECTING_DELETIONS
+    onProgress.accept(new JobProgress("DETECTING_DELETIONS",
+        "Prüfe gelöschte Seiten...", 0, 0, chunksCreated, errors, spaceKey));
+
+    // Phase: DELETING (pro gelöschter Seite)
+    for (int i = 0; i < deletedPageIds.size(); i++) {
+        onProgress.accept(new JobProgress("DELETING",
+            String.format("Lösche Seite %d/%d", i + 1, deletedPageIds.size()),
+            i + 1, deletedPageIds.size(), chunksCreated, errors, spaceKey));
+        // ... delete logic ...
+    }
+}
+```
+
+### 2.6 AdminController-Anpassung
+
+```java
+@PostMapping("/ingest")
+public ResponseEntity<JobStatus> triggerIngestion() {
+    if (isRunning()) return ResponseEntity.status(409).body(currentJob.get());
+
+    currentJob.set(new JobStatus("running", "ingest", null, null, null));
+
+    Consumer<JobProgress> onProgress = progress ->
+        currentJob.set(new JobStatus("running", "ingest", null, null, progress));
+
+    CompletableFuture.runAsync(() -> {
+        try {
+            IngestionResult result = ingestionService.ingestAll(onProgress);
+            currentJob.set(new JobStatus("completed", "ingest", result, null, null));
+        } catch (Exception e) {
+            currentJob.set(new JobStatus("failed", "ingest", null, e.getMessage(), null));
+        }
+    });
+    return ResponseEntity.accepted().body(currentJob.get());
+}
+```
+
+## 3. Frontend-Design
+
+### 3.1 Progress Bar HTML (im Admin Panel)
+
+```html
+<!-- Neues Element im Admin Panel, über den Space-Rows -->
+<div id="job-progress" class="job-progress hidden">
+    <div class="job-progress-header">
+        <span id="job-progress-phase" class="job-progress-phase"></span>
+        <span id="job-progress-percent" class="job-progress-percent"></span>
+    </div>
+    <div class="progress-bar-container">
+        <div id="job-progress-bar" class="progress-bar"></div>
+    </div>
+    <div id="job-progress-detail" class="job-progress-detail"></div>
+    <div class="job-progress-stats">
+        <span id="job-progress-chunks"></span>
+        <span id="job-progress-errors"></span>
+    </div>
+</div>
+```
+
+### 3.2 Progress Bar Styling
+
+```css
+.job-progress {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 12px;
+}
+.job-progress.hidden { display: none; }
+
+.job-progress-header {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 6px;
+    font-size: 0.85rem;
+}
+.job-progress-phase { font-weight: 600; }
+.job-progress-percent { color: var(--text-secondary); }
+
+.progress-bar-container {
+    height: 8px;
+    background: var(--border);
+    border-radius: 4px;
+    overflow: hidden;
+}
+.progress-bar {
+    height: 100%;
+    background: var(--primary);
+    border-radius: 4px;
+    transition: width 0.3s ease;
+    width: 0%;
+}
+
+.job-progress-detail {
+    margin-top: 6px;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.job-progress-stats {
+    display: flex;
+    gap: 16px;
+    margin-top: 4px;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+```
+
+### 3.3 JavaScript-Erweiterung
+
+```javascript
+// Erweiterte pollJobStatus() — Progress Bar aktualisieren
+async function pollJobStatus(label) {
+    showProgress(true);
+    const poll = setInterval(async () => {
+        const res = await fetch(`${API_BASE}/admin/job/status`);
+        const job = await res.json();
+
+        if (job.status === 'running' && job.progress) {
+            updateProgress(job.progress);
+        }
+
+        if (job.status === 'completed' || job.status === 'failed') {
+            clearInterval(poll);
+            showProgress(false);
+            // ... bestehende Logik ...
+        }
+    }, 3000);
+}
+
+function updateProgress(p) {
+    const phaseLabels = {
+        'CRAWLING': 'Crawling...',
+        'CHUNKING': 'Chunking...',
+        'STORING': 'Speichern...',
+        'CRAWLING_CHANGES': 'Änderungen ermitteln...',
+        'UPDATING': 'Aktualisieren...',
+        'DETECTING_DELETIONS': 'Löschungen erkennen...',
+        'DELETING': 'Löschen...'
+    };
+
+    document.getElementById('job-progress-phase').textContent =
+        phaseLabels[p.phase] || p.phase;
+    document.getElementById('job-progress-percent').textContent =
+        p.totalItems > 0 ? `${p.percentComplete}%` : '';
+    document.getElementById('job-progress-bar').style.width =
+        (p.totalItems > 0 ? p.percentComplete : 0) + '%';
+    document.getElementById('job-progress-detail').textContent =
+        p.detail || '';
+    document.getElementById('job-progress-chunks').textContent =
+        p.chunksProcessed > 0 ? `${p.chunksProcessed} Chunks` : '';
+    document.getElementById('job-progress-errors').textContent =
+        p.errors > 0 ? `${p.errors} Fehler` : '';
+}
+
+function showProgress(visible) {
+    document.getElementById('job-progress').classList.toggle('hidden', !visible);
+}
+```
+
+### 3.4 Progress-Darstellung (Mockup)
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Chunking...                                       62%  │
+│  ████████████████████████████░░░░░░░░░░░░░░░░░░░░       │
+│  Seite 26/42 — 'API-Dokumentation'                      │
+│  156 Chunks                                             │
+└─────────────────────────────────────────────────────────┘
+```
+
+## 4. API-Response-Beispiel
+
+### GET /api/admin/job/status (während Ingest)
+
+```json
+{
+  "status": "running",
+  "operation": "ingest",
+  "result": null,
+  "error": null,
+  "progress": {
+    "phase": "CHUNKING",
+    "detail": "Seite 26/42 — 'API-Dokumentation'",
+    "currentItem": 26,
+    "totalItems": 42,
+    "chunksProcessed": 156,
+    "errors": 0,
+    "currentSpace": "DS",
+    "percentComplete": 61
+  }
+}
+```
+
+### GET /api/admin/job/status (nach Abschluss)
+
+```json
+{
+  "status": "completed",
+  "operation": "ingest",
+  "result": {
+    "spacesProcessed": 2,
+    "pagesProcessed": 42,
+    "chunksCreated": 380,
+    "chunksStored": 378,
+    "errors": 2,
+    "duration": 83.0
+  },
+  "error": null,
+  "progress": null
+}
+```
+
+## 5. Implementierungsplan
+
+| Schritt | Beschreibung | Dateien |
+|---------|-------------|---------|
+| 1 | `JobProgress` Record erstellen | `AdminController.java` |
+| 2 | `JobStatus` um `progress`-Feld erweitern | `AdminController.java` |
+| 3 | `IngestionService` um `Consumer<JobProgress>` erweitern | `IngestionService.java` |
+| 4 | `SyncService` um `Consumer<JobProgress>` erweitern | `SyncService.java` |
+| 5 | `AdminController` Endpoints anpassen (Callback übergeben) | `AdminController.java` |
+| 6 | Frontend: Progress Bar HTML + CSS | `index.html`, `style.css` |
+| 7 | Frontend: `pollJobStatus()` erweitern, `updateProgress()` | `app.js` |
+| 8 | Tests anpassen/erweitern | Tests |
+
+## 6. Abgrenzung
+
+**Nicht in Scope:**
+- WebSocket/SSE für Push-basierte Updates (Polling reicht)
+- Progress-Persistenz (nur In-Memory)
+- Abbrechen laufender Jobs (separates Feature)
+- ETA/Zeitschätzung (zu ungenau bei variablen Seitengrößen)
+- Crawling-Unterfortschritt (Confluence-API gibt Seitenanzahl erst nach Pagination zurück)

--- a/scripts/generate-test-pages.py
+++ b/scripts/generate-test-pages.py
@@ -1,0 +1,1005 @@
+#!/usr/bin/env python3
+"""Generate ~100 test pages in Confluence OP space from repo docs/specs."""
+
+import json
+import re
+import sys
+import time
+import urllib.request
+import urllib.error
+import base64
+import os
+import html
+
+BASE_URL = "http://localhost:8090"
+SPACE_KEY = "OP"
+AUTH = base64.b64encode(b"admin:admin").decode()
+SPECS_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "docs", "specs")
+
+created = 0
+
+
+def api(method, path, data=None):
+    url = f"{BASE_URL}/rest/api{path}"
+    req = urllib.request.Request(url, method=method)
+    req.add_header("Authorization", f"Basic {AUTH}")
+    req.add_header("Content-Type", "application/json")
+    if data:
+        req.data = json.dumps(data).encode()
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"  ERROR {e.code}: {body[:200]}")
+        return None
+
+
+def create_page(title, body_html, parent_id=None):
+    global created
+    data = {
+        "type": "page",
+        "title": title,
+        "space": {"key": SPACE_KEY},
+        "body": {
+            "storage": {
+                "value": body_html,
+                "representation": "storage"
+            }
+        }
+    }
+    if parent_id:
+        data["ancestors"] = [{"id": parent_id}]
+
+    result = api("POST", "/content", data)
+    if result and "id" in result:
+        created += 1
+        print(f"  [{created:3d}] {title}")
+        return int(result["id"])
+    return None
+
+
+def h(text):
+    """HTML-escape text."""
+    return html.escape(text)
+
+
+def md_to_storage(md_text):
+    """Convert markdown-ish text to Confluence storage format (simple)."""
+    lines = md_text.strip().split("\n")
+    out = []
+    in_code = False
+    in_list = False
+    in_table = False
+
+    code_lines = []
+
+    for line in lines:
+        # Code blocks — use simple <pre> to avoid CDATA issues
+        if line.strip().startswith("```"):
+            if in_code:
+                out.append(f"<pre>{h(chr(10).join(code_lines))}</pre>")
+                code_lines = []
+                in_code = False
+            else:
+                in_code = True
+            continue
+
+        if in_code:
+            code_lines.append(line)
+            continue
+
+        # Headings
+        m = re.match(r'^(#{1,6})\s+(.*)', line)
+        if m:
+            if in_list:
+                out.append("</ul>")
+                in_list = False
+            level = len(m.group(1))
+            out.append(f"<h{level}>{h(m.group(2))}</h{level}>")
+            continue
+
+        # Table rows
+        if "|" in line and line.strip().startswith("|"):
+            cells = [c.strip() for c in line.strip().strip("|").split("|")]
+            if all(re.match(r'^[-:]+$', c) for c in cells):
+                continue  # separator row
+            if not in_table:
+                out.append("<table><tbody>")
+                in_table = True
+            out.append("<tr>" + "".join(f"<td>{h(c)}</td>" for c in cells) + "</tr>")
+            continue
+        elif in_table:
+            out.append("</tbody></table>")
+            in_table = False
+
+        # List items
+        if re.match(r'^[-*]\s', line.strip()):
+            if not in_list:
+                out.append("<ul>")
+                in_list = True
+            item = re.sub(r'^[-*]\s+', '', line.strip())
+            # Handle checkbox items
+            item = re.sub(r'^\[[ x]\]\s*', '', item)
+            out.append(f"<li>{h(item)}</li>")
+            continue
+        elif in_list and line.strip() == "":
+            out.append("</ul>")
+            in_list = False
+
+        # Bold/italic
+        text = line
+        text = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', text)
+        text = re.sub(r'\*(.+?)\*', r'<em>\1</em>', text)
+        text = re.sub(r'`(.+?)`', r'<code>\1</code>', text)
+
+        # Empty line
+        if line.strip() == "":
+            continue
+
+        # Paragraph
+        if not line.startswith("<"):
+            out.append(f"<p>{text}</p>")
+        else:
+            out.append(text)
+
+    if in_list:
+        out.append("</ul>")
+    if in_table:
+        out.append("</tbody></table>")
+    if in_code:
+        out.append(f"<pre>{h(chr(10).join(code_lines))}</pre>")
+
+    return "\n".join(out)
+
+
+def split_sections(md_text, level=2):
+    """Split markdown by heading level into (title, body) pairs."""
+    pattern = rf'^({"#" * level})\s+(.+)'
+    sections = []
+    current_title = None
+    current_lines = []
+
+    for line in md_text.split("\n"):
+        m = re.match(pattern, line)
+        if m:
+            if current_title:
+                sections.append((current_title, "\n".join(current_lines)))
+            current_title = m.group(2)
+            current_lines = []
+        else:
+            current_lines.append(line)
+
+    if current_title:
+        sections.append((current_title, "\n".join(current_lines)))
+
+    return sections
+
+
+def generate_additional_pages(parent_id, topic, base_content, start_idx, count):
+    """Generate additional pages by creating variations/deep-dives of content."""
+    pages_created = 0
+    sections = split_sections(base_content, level=3)
+
+    for i, (title, body) in enumerate(sections):
+        if pages_created >= count:
+            break
+        sub_sections = split_sections(body, level=4)
+        if sub_sections:
+            sub_parent = create_page(
+                f"{topic} — {title}",
+                md_to_storage(body),
+                parent_id
+            )
+            if sub_parent:
+                pages_created += 1
+                for st, sb in sub_sections:
+                    if pages_created >= count:
+                        break
+                    create_page(
+                        f"{topic} — {st}",
+                        md_to_storage(sb),
+                        sub_parent
+                    )
+                    pages_created += 1
+        else:
+            create_page(
+                f"{topic} — {title}",
+                md_to_storage(body),
+                parent_id
+            )
+            pages_created += 1
+
+    return pages_created
+
+
+# Additional content templates for padding to 100 pages
+EXTRA_TOPICS = [
+    ("Architektur-Entscheidungen", [
+        ("ADR-001: Spring AI statt LangChain", """
+## Kontext
+Fuer die RAG-Pipeline wurde ein Framework zur Integration von LLM und Vektordatenbank benoetigt.
+
+## Entscheidung
+Spring AI 1.0.0 wurde gewaehlt, da es nativ in das Spring-Oekosystem integriert ist.
+
+## Gruende
+- Nahtlose Integration mit Spring Boot Auto-Configuration
+- Einheitliches Abstraktionsmodell fuer verschiedene LLM-Provider
+- Native VectorStore-Abstraktion mit Qdrant-Support
+- Aktive Weiterentwicklung durch VMware/Broadcom
+
+## Konsequenzen
+- Abhaengigkeit von Spring AI Release-Zyklus
+- API-Aenderungen zwischen Minor-Versionen moeglich
+- Dokumentation teilweise noch lueckenhaft
+"""),
+        ("ADR-002: Qdrant als Vektordatenbank", """
+## Kontext
+Fuer die Speicherung der Embedding-Vektoren wurde eine performante Vektordatenbank benoetigt.
+
+## Optionen
+| Option | Pros | Cons |
+| Qdrant | Schnell, Filter-Support, gRPC | Weniger verbreitet |
+| Chroma | Einfach, Python-native | Kein gRPC, langsamer |
+| Pinecone | Managed, skalierbar | Cloud-only, Kosten |
+| Weaviate | GraphQL, Hybrid-Search | Komplex, Overhead |
+
+## Entscheidung
+Qdrant wurde gewaehlt wegen:
+- Hohe Performance bei Similarity Search
+- Native Filter-Expressions (Space-Filter)
+- gRPC-Support fuer schnelle Batch-Operationen
+- Einfaches Docker-Setup
+- Spring AI VectorStore Integration vorhanden
+
+## Konsequenzen
+- Self-hosted Betrieb noetig
+- Backup-Strategie muss implementiert werden
+"""),
+        ("ADR-003: Ollama fuer lokale LLM-Inferenz", """
+## Kontext
+Das Projekt soll ohne Cloud-Abhaengigkeiten lokal betrieben werden koennen.
+
+## Entscheidung
+Ollama als lokaler LLM-Runner fuer Chat und Embedding.
+
+## Modellauswahl
+- Embedding: nomic-embed-text (768 Dimensionen, mehrsprachig)
+- Chat: mistral oder llama3 (je nach verfuegbarem RAM)
+
+## Vorteile
+- Keine API-Kosten
+- Datenschutz: Alle Daten bleiben lokal
+- Einfache Installation und Modellverwaltung
+- GPU-Beschleunigung wenn verfuegbar
+
+## Nachteile
+- Hardware-Anforderungen (min. 8GB RAM fuer 7B-Modelle)
+- Langsamere Inferenz als Cloud-APIs
+- Modellqualitaet unter GPT-4/Claude
+"""),
+        ("ADR-004: Jsoup XML Parser fuer Confluence Storage Format", """
+## Kontext
+Confluence speichert Seiteninhalte im XHTML Storage Format mit proprietaeren Namespaces (ac:, ri:).
+
+## Problem
+Standard HTML-Parser (auch Jsoup im HTML-Modus) verwerfen unbekannte Namespaces.
+
+## Entscheidung
+Jsoup im XML-Parser-Modus verwenden: `Parser.xmlParser()`
+
+## Gruende
+- Erhalt der ac:structured-macro Elemente
+- Korrekte Verarbeitung von ri:attachment, ri:page etc.
+- Keine zusaetzliche Abhaengigkeit noetig
+- Robuste Fehlerbehandlung bei malformed XML
+
+## Konsequenzen
+- XML-Parser ist strenger als HTML-Parser
+- Einige HTML-Entities muessen escaped werden
+- MacroHandler-Pattern fuer verschiedene Makro-Typen
+"""),
+    ]),
+    ("Betriebshandbuch", [
+        ("Installation und Ersteinrichtung", """
+## Voraussetzungen
+- Java 17 oder hoeher
+- Docker und Docker Compose
+- Min. 8 GB RAM (16 GB empfohlen fuer LLM)
+- Netzwerkzugang zum Confluence-Server
+
+## Installationsschritte
+
+### 1. Repository klonen
+```bash
+git clone https://github.com/martinvidec/openaustria-confluence-rag.git
+cd openaustria-confluence-rag
+```
+
+### 2. Infrastruktur starten
+```bash
+docker compose up -d qdrant ollama
+```
+
+### 3. Ollama-Modelle laden
+```bash
+ollama pull nomic-embed-text
+ollama pull mistral
+```
+
+### 4. Applikation starten
+```bash
+export CONFLUENCE_BASE_URL=https://confluence.example.com
+export CONFLUENCE_PAT=your-token-here
+export CONFLUENCE_SPACES=DEV,OPS
+mvn spring-boot:run
+```
+
+## Erster Ingest
+Nach dem Start die Web-UI oeffnen unter http://localhost:8080, Admin-Panel oeffnen und "Alle Spaces neu ingesten" klicken.
+"""),
+        ("Monitoring und Logging", """
+## Log-Konfiguration
+Die Applikation verwendet SLF4J mit Logback.
+
+### Log-Level pro Komponente
+| Komponente | Default Level | Beschreibung |
+| CrawlerService | INFO | Seitenfortschritt, Fehler |
+| IngestionService | INFO | Chunk/Batch-Fortschritt |
+| SyncService | INFO | Sync-Ergebnisse |
+| QueryService | INFO | Anfragen und Antwortzeiten |
+| ConfluenceClient | WARN | Nur Retries und Fehler |
+
+### Debug-Logging aktivieren
+```yaml
+logging:
+  level:
+    at.openaustria.confluencerag: DEBUG
+```
+
+## Health Checks
+- Spring Actuator: `GET /actuator/health`
+- Qdrant Dashboard: http://localhost:6333/dashboard
+- Ollama API: `curl http://localhost:11434/api/tags`
+
+## Metriken
+- Ingest-Dauer pro Space
+- Chunk-Anzahl pro Space
+- Fehlerrate bei Embedding-Requests
+- Antwortzeit der Chat-API
+"""),
+        ("Backup und Recovery", """
+## Qdrant Backup
+Qdrant-Daten liegen im Docker Volume `qdrant_data`.
+
+### Snapshot erstellen
+```bash
+curl -X POST http://localhost:6333/collections/confluence-chunks/snapshots
+```
+
+### Snapshot wiederherstellen
+```bash
+curl -X PUT http://localhost:6333/collections/confluence-chunks/snapshots/recover \\
+  -H "Content-Type: application/json" \\
+  -d '{"location": "file:///qdrant/snapshots/snapshot-name.snapshot"}'
+```
+
+## Sync-State Backup
+Die Datei `./data/sync-state.json` enthaelt den letzten Sync-Zeitpunkt und bekannte Seiten-IDs pro Space. Bei Verlust wird beim naechsten Sync ein Voll-Crawl durchgefuehrt.
+
+## Disaster Recovery
+1. Docker Volumes wiederherstellen oder neu erstellen
+2. Qdrant Collection wird automatisch angelegt (initialize-schema: true)
+3. Voll-Ingest aller Spaces durchfuehren
+4. Dauer: abhaengig von Confluence-Groesse (ca. 1 Seite/Sekunde)
+"""),
+        ("Fehlerbehebung und Troubleshooting", """
+## Haeufige Probleme
+
+### Embedding-Timeout
+**Symptom:** Batch-Timeout nach 120 Sekunden beim Storing
+**Ursache:** Ollama-Server ueberlastet oder Modell nicht geladen
+**Loesung:**
+```bash
+# Pruefen ob Modell geladen ist
+ollama list
+# Modell neu laden
+ollama pull nomic-embed-text
+```
+
+### Confluence API 401 Unauthorized
+**Symptom:** CrawlerService meldet HTTP 401
+**Ursache:** PAT abgelaufen oder falsche Credentials
+**Loesung:** Neuen PAT in Confluence generieren und Environment-Variable aktualisieren
+
+### Qdrant Connection Refused
+**Symptom:** Applikation startet nicht, Connection refused auf Port 6334
+**Ursache:** Qdrant-Container nicht gestartet
+**Loesung:**
+```bash
+docker compose up -d qdrant
+# Warten bis Container healthy ist
+docker compose ps
+```
+
+### Out of Memory bei grossen Spaces
+**Symptom:** Java OutOfMemoryError bei Ingest
+**Ursache:** Zu viele Seiten/Chunks gleichzeitig im Speicher
+**Loesung:** JVM Heap erhoehen:
+```bash
+JAVA_OPTS="-Xmx4g" mvn spring-boot:run
+```
+"""),
+        ("Performance-Tuning", """
+## Chunk-Konfiguration
+Die Chunk-Groesse beeinflusst Qualitaet und Performance:
+
+| Parameter | Default | Beschreibung |
+| chunkSize | 800 | Token pro Chunk |
+| chunkOverlap | 100 | Ueberlappung zwischen Chunks |
+| batchSize | 50 | Chunks pro Qdrant-Batch |
+
+### Groessere Chunks
+- Mehr Kontext pro Chunk = bessere Antworten
+- Aber: Weniger praezise Suche, mehr Token-Verbrauch
+
+### Kleinere Chunks
+- Praezisere Similarity Search
+- Aber: Kontext kann verloren gehen
+
+## Empfehlung
+- Fuer technische Dokumentation: 800 Token (Default)
+- Fuer kurze FAQ-Seiten: 400 Token
+- Fuer lange Berichte: 1200 Token
+
+## Qdrant-Optimierung
+- Collection mit HNSW Index (Default)
+- ef_construct: 128 (Default, guter Kompromiss)
+- Fuer groessere Datenmengen (>100k Chunks): ef_construct auf 256 erhoehen
+"""),
+    ]),
+    ("API-Dokumentation", [
+        ("Chat API Endpunkte", """
+## POST /api/chat
+Synchrone Chat-Anfrage.
+
+### Request
+```json
+{
+  "question": "Wie funktioniert der Sync?",
+  "spaceFilter": ["DS", "OP"]
+}
+```
+
+### Response
+```json
+{
+  "answer": "Der Sync-Prozess...",
+  "sources": [
+    {
+      "title": "Sync-Dokumentation",
+      "url": "https://confluence.example.com/...",
+      "spaceKey": "DS"
+    }
+  ]
+}
+```
+
+## POST /api/chat/stream
+Server-Sent Events fuer Streaming-Antworten.
+
+### SSE Events
+| Event | Data | Beschreibung |
+| token | {"token": "..."} | Einzelnes Token der Antwort |
+| sources | {"sources": [...]} | Quellenangaben |
+| done | {} | Stream beendet |
+| error | {"message": "..."} | Fehler aufgetreten |
+
+### Beispiel mit curl
+```bash
+curl -N -X POST http://localhost:8080/api/chat/stream \\
+  -H "Content-Type: application/json" \\
+  -d '{"question": "Was ist Spring AI?"}'
+```
+"""),
+        ("Admin API Endpunkte", """
+## POST /api/admin/ingest
+Startet Voll-Ingest aller konfigurierten Spaces.
+
+### Response (202 Accepted)
+```json
+{
+  "status": "running",
+  "operation": "ingest",
+  "result": null,
+  "error": null,
+  "progress": null
+}
+```
+
+## POST /api/admin/ingest/{spaceKey}
+Startet Voll-Ingest eines einzelnen Space.
+
+## POST /api/admin/sync
+Startet inkrementellen Sync aller Spaces.
+
+## POST /api/admin/sync/{spaceKey}
+Startet inkrementellen Sync eines einzelnen Space.
+
+## GET /api/admin/job/status
+Gibt den aktuellen Job-Status zurueck. Waehrend ein Job laeuft, enthaelt das progress-Feld Live-Fortschrittsdaten.
+
+### Response (waehrend Job)
+```json
+{
+  "status": "running",
+  "operation": "ingest",
+  "progress": {
+    "phase": "CHUNKING",
+    "detail": "Seite 5/42 - 'API Docs'",
+    "currentItem": 5,
+    "totalItems": 42,
+    "chunksProcessed": 28,
+    "errors": 0,
+    "currentSpace": "DS",
+    "percentComplete": 11
+  }
+}
+```
+
+## GET /api/admin/sync/status
+Gibt den Sync-Status aller Spaces zurueck.
+
+### Response
+```json
+{
+  "DS": {
+    "lastSync": "2026-03-24T15:30:00Z",
+    "knownPageIds": ["12345", "67890"]
+  }
+}
+```
+
+## GET /api/spaces
+Gibt alle konfigurierten Spaces zurueck.
+"""),
+        ("Datenmodell und DTOs", """
+## ConfluenceDocument
+Das zentrale Datenmodell fuer gecrawlte Seiten.
+
+### Felder
+| Feld | Typ | Beschreibung |
+| pageId | long | Confluence Page ID |
+| spaceKey | String | Space-Schluessel |
+| spaceName | String | Space-Name |
+| title | String | Seitentitel |
+| url | String | Web-URL der Seite |
+| bodyText | String | Konvertierter Plaintext |
+| labels | List of String | Seiten-Labels |
+| comments | List of CommentDocument | Kommentare |
+| attachments | List of AttachmentDocument | Attachments |
+| author | String | Letzter Autor |
+| lastModified | Instant | Letzte Aenderung |
+| ancestors | List of String | Breadcrumb-Titel |
+
+## CommentDocument
+| Feld | Typ | Beschreibung |
+| id | long | Comment ID |
+| bodyText | String | Kommentar-Text |
+| author | String | Autor |
+| created | Instant | Erstellungszeitpunkt |
+
+## AttachmentDocument
+| Feld | Typ | Beschreibung |
+| id | long | Attachment ID |
+| title | String | Dateiname |
+| mediaType | String | MIME-Typ |
+| extractedText | String | Extrahierter Text |
+
+## IngestionResult
+| Feld | Typ | Beschreibung |
+| spacesProcessed | int | Anzahl Spaces |
+| pagesProcessed | int | Anzahl Seiten |
+| chunksCreated | int | Erzeugte Chunks |
+| chunksStored | int | Gespeicherte Chunks |
+| errors | int | Fehler |
+| duration | Duration | Dauer |
+
+## SyncResult
+| Feld | Typ | Beschreibung |
+| pagesUpdated | int | Aktualisierte Seiten |
+| pagesDeleted | int | Geloeschte Seiten |
+| pagesNew | int | Neue Seiten |
+| chunksCreated | int | Neue Chunks |
+| errors | int | Fehler |
+| duration | Duration | Dauer |
+"""),
+    ]),
+    ("Confluence-Integration", [
+        ("Authentifizierung und Zugriffskontrolle", """
+## Authentifizierungsmethoden
+
+### Personal Access Token (PAT) — Empfohlen
+PATs sind die bevorzugte Methode fuer API-Zugriffe:
+
+1. In Confluence: Profil > Einstellungen > Persoenliche Zugriffstoken
+2. Token erstellen mit Leseberechtigung
+3. Token als Umgebungsvariable setzen:
+```bash
+export CONFLUENCE_PAT=your-token-here
+```
+
+### Basic Authentication
+Alternativ fuer lokale Testinstanzen:
+```bash
+export CONFLUENCE_USERNAME=admin
+export CONFLUENCE_PASSWORD=admin
+```
+
+## Berechtigungen
+Der API-Benutzer benoetigt:
+- Lesezugriff auf alle zu crawlenden Spaces
+- Lesezugriff auf Seiteninhalte (body.storage)
+- Lesezugriff auf Kommentare und Attachments
+- Lesezugriff auf Metadaten (Labels, Versionen)
+
+## Rate Limiting
+Die Confluence REST API hat standardmaessig keine Rate Limits. Bei gehosteten Instanzen (Confluence Cloud) gelten folgende Limits:
+- 100 Requests pro Minute pro Benutzer
+- Retry mit exponentiellem Backoff implementiert (1s, 2s, 4s)
+- Maximal 3 Retries pro Request
+"""),
+        ("CQL-Abfragen fuer Delta-Sync", """
+## Confluence Query Language (CQL)
+
+### Grundlagen
+CQL ist die Abfragesprache fuer Confluence-Inhalte. Sie wird fuer den inkrementellen Sync verwendet.
+
+### Delta-Query
+```
+type = page AND space = "DS" AND lastModified >= "2026-03-20"
+```
+
+### Operatoren
+| Operator | Beschreibung | Beispiel |
+| = | Gleich | type = page |
+| != | Ungleich | type != blogpost |
+| >= | Groesser/gleich | lastModified >= "2026-01-01" |
+| IN | In Liste | space IN ("DS", "OP") |
+| AND | Logisches UND | type = page AND space = "DS" |
+| OR | Logisches ODER | title = "A" OR title = "B" |
+| ORDER BY | Sortierung | ORDER BY lastModified DESC |
+
+### Verwendung im SyncService
+1. Letzten Sync-Zeitpunkt aus State-File lesen
+2. CQL-Query mit lastModified-Filter ausfuehren
+3. Nur geaenderte Seiten zurueckbekommen
+4. Re-Chunking und Re-Embedding dieser Seiten
+5. Geloeschte Seiten durch ID-Vergleich erkennen
+"""),
+        ("Confluence Storage Format", """
+## XHTML Storage Format
+
+Confluence speichert Seiteninhalte im sogenannten "Storage Format" — einem erweiterten XHTML mit proprietaeren Namespaces.
+
+### Standard-Elemente
+| HTML | Confluence Storage |
+| Absatz | `<p>Text</p>` |
+| Ueberschrift | `<h1>` bis `<h6>` |
+| Fett | `<strong>` oder `<b>` |
+| Kursiv | `<em>` oder `<i>` |
+| Liste | `<ul>/<ol>` mit `<li>` |
+| Tabelle | `<table>` mit `<tr>`, `<th>`, `<td>` |
+| Link | `<a href="...">` |
+| Bild | `<ac:image>` mit `<ri:attachment>` |
+
+### Confluence-spezifische Elemente
+| Element | Namespace | Beschreibung |
+| structured-macro | ac: | Makros (Code, Info, Warning) |
+| rich-text-body | ac: | Makro-Body mit Formatierung |
+| plain-text-body | ac: | Makro-Body ohne Formatierung |
+| attachment | ri: | Referenz auf Attachment |
+| page | ri: | Referenz auf andere Seite |
+| user | ri: | Referenz auf Benutzer |
+
+### Makro-Beispiele
+Code-Makro:
+```xml
+<ac:structured-macro ac:name="code">
+  <ac:parameter ac:name="language">java</ac:parameter>
+  <ac:plain-text-body><![CDATA[
+    public class Hello { }
+  ]]></ac:plain-text-body>
+</ac:structured-macro>
+```
+
+Info-Makro:
+```xml
+<ac:structured-macro ac:name="info">
+  <ac:rich-text-body>
+    <p>Dies ist ein Hinweis.</p>
+  </ac:rich-text-body>
+</ac:structured-macro>
+```
+"""),
+        ("Attachment-Verarbeitung", """
+## Unterstuetzte Dateiformate
+
+| Format | MIME-Type | Extraktion |
+| PDF | application/pdf | Apache Tika |
+| Word (DOC) | application/msword | Apache Tika |
+| Word (DOCX) | application/vnd.openxmlformats-officedocument.wordprocessingml.document | Apache Tika |
+| Excel (XLSX) | application/vnd.openxmlformats-officedocument.spreadsheetml.sheet | Apache Tika |
+| PowerPoint | application/vnd.openxmlformats-officedocument.presentationml.presentation | Apache Tika |
+| Text | text/plain | Direktes Lesen |
+
+## Verarbeitungsprozess
+1. Attachments der Seite ueber REST API abrufen
+2. MIME-Type pruefen (nur unterstuetzte Formate)
+3. Dateigroesse pruefen (max. 50 MB)
+4. Datei herunterladen
+5. Text mit Apache Tika extrahieren
+6. Extrahierten Text als AttachmentDocument speichern
+7. Beim Chunking als eigener Chunk-Typ "ATTACHMENT" verarbeiten
+
+## Fehlerbehandlung
+- Einzelne Attachment-Fehler brechen nicht den gesamten Crawl ab
+- Nicht-unterstuetzte Formate werden uebersprungen (DEBUG-Log)
+- Grosse Dateien werden uebersprungen (WARN-Log)
+- Tika-Extraktionsfehler werden geloggt, Seite wird trotzdem verarbeitet
+
+## Performance-Ueberlegungen
+- Grosse PDF-Dateien koennen die Crawl-Dauer signifikant verlaengern
+- Parallelisierung der Attachment-Downloads moeglich (aktuell sequenziell)
+- Tika-Extraktion ist CPU-intensiv bei grossen Dokumenten
+"""),
+    ]),
+    ("Entwickler-Dokumentation", [
+        ("Lokale Entwicklungsumgebung", """
+## Voraussetzungen
+- JDK 17 (empfohlen: Homebrew openjdk@17 auf macOS)
+- Maven 3.9+
+- Docker Desktop
+- IDE: IntelliJ IDEA (empfohlen) oder VS Code mit Java Extension
+
+## Setup
+```bash
+# Java konfigurieren
+export JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home
+
+# Projekt kompilieren
+mvn clean compile
+
+# Tests ausfuehren
+mvn test
+
+# Infrastruktur starten
+docker compose up -d qdrant ollama
+
+# Applikation starten
+CONFLUENCE_USERNAME=admin CONFLUENCE_PASSWORD=admin \\
+CONFLUENCE_SPACES=ds,OP OLLAMA_CHAT_MODEL=mistral \\
+mvn spring-boot:run -DskipTests
+```
+
+## Test-Confluence
+Fuer lokale Tests steht eine Confluence-Instanz zur Verfuegung:
+```bash
+docker compose -f docker-compose.test.yml up -d
+# Confluence UI: http://localhost:8090
+# Login: admin / admin
+```
+
+## IDE-Konfiguration
+### IntelliJ IDEA
+- Import als Maven-Projekt
+- SDK auf Java 17 setzen
+- Spring Boot Run Configuration mit Environment Variables
+"""),
+        ("Coding Conventions", """
+## Allgemein
+- Java 17 Features nutzen (Records, Pattern Matching, Text Blocks)
+- Sprache im Code: Englisch (Variablen, Methoden, Klassen)
+- Sprache in Dokumentation: Deutsch
+- Spring AI 1.0.0 API verwenden (nicht die alten Starter-Namen)
+
+## Package-Struktur
+```
+at.openaustria.confluencerag
+├── config/      # @Configuration, @ConfigurationProperties
+├── crawler/     # Confluence API Client, HTML Converter
+│   ├── client/
+│   ├── converter/
+│   └── model/
+├── ingestion/   # Chunking, Embedding, Sync
+├── query/       # RAG Query Service
+└── web/         # REST Controller, DTOs
+```
+
+## Naming Conventions
+| Element | Convention | Beispiel |
+| Klasse | PascalCase | ConfluenceClient |
+| Methode | camelCase | crawlSpace |
+| Konstante | SCREAMING_SNAKE | MAX_ATTACHMENT_SIZE |
+| Record | PascalCase | IngestionResult |
+| Property | kebab-case | confluence.base-url |
+
+## Spring AI Spezifika
+- `Document.getText()` statt `getContent()` (seit 1.0.0)
+- `SearchRequest.builder().query()` statt `SearchRequest.query()`
+- `spring.ai.ollama.chat.model` statt `spring.ai.ollama.chat.options.model`
+
+## Error Handling
+- Runtime Exceptions statt Checked Exceptions
+- Fehler loggen und weiterverarbeiten (keine Silent Failures)
+- @JsonIgnoreProperties(ignoreUnknown = true) auf alle DTOs
+"""),
+        ("Testkonzept", """
+## Teststrategie
+
+### Unit Tests
+- JUnit 5 + Mockito
+- Fokus auf Converter, Chunking, Hilfsklassen
+- Keine Spring-Context-Tests wo moeglich
+
+### Integration Tests
+- ConfluenceClientTest mit eingebettetem HttpServer
+- Mock-Server fuer Confluence REST API
+- Tests fuer Pagination, Retry, Authentication
+
+### Testabdeckung
+| Komponente | Tests | Abdeckung |
+| ConfluenceHtmlConverter | 24 | Alle HTML-Elemente, Makros |
+| ConfluenceClient | 5 | Pagination, Retry, Auth |
+| ChunkingService | 6 | Chunking, Metadata, Limits |
+| ConfluenceRagApplication | 1 | Context-Load |
+
+### Testausfuehrung
+```bash
+# Alle Tests
+mvn test
+
+# Einzelne Testklasse
+mvn test -Dtest=ConfluenceHtmlConverterTest
+
+# Mit Coverage
+mvn test jacoco:report
+```
+
+## Test-Fixtures
+- HTML-Snippets fuer Converter-Tests
+- Mock-JSON-Responses fuer Client-Tests
+- ConfluenceDocument-Instanzen fuer Chunking-Tests
+"""),
+        ("Build und Deployment Pipeline", """
+## Build-Prozess
+
+### Lokaler Build
+```bash
+mvn clean package -DskipTests
+```
+
+### Docker Image erstellen
+```bash
+docker build -t confluence-rag:latest .
+```
+
+### Dockerfile
+```dockerfile
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+COPY target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]
+```
+
+## Deployment-Optionen
+
+### Docker Compose (Empfohlen)
+Alle Services in einem docker-compose.yml:
+- confluence-rag (Applikation)
+- qdrant (Vektordatenbank)
+- ollama (LLM-Server)
+
+### Standalone
+```bash
+java -jar target/confluence-rag-0.0.1-SNAPSHOT.jar \\
+  --confluence.base-url=https://confluence.example.com \\
+  --confluence.pat=your-token
+```
+
+## Umgebungsvariablen
+| Variable | Beschreibung | Default |
+| CONFLUENCE_BASE_URL | Confluence Server URL | http://localhost:8090 |
+| CONFLUENCE_PAT | Personal Access Token | - |
+| CONFLUENCE_SPACES | Komma-separierte Space Keys | - |
+| OLLAMA_BASE_URL | Ollama Server URL | http://localhost:11434 |
+| OLLAMA_CHAT_MODEL | Chat-Modell | llama3 |
+| QDRANT_HOST | Qdrant Hostname | localhost |
+"""),
+    ]),
+]
+
+
+def main():
+    global created
+    print(f"Generating test pages in Confluence space {SPACE_KEY}...")
+    print(f"Reading specs from {SPECS_DIR}")
+    print()
+
+    # Get homepage ID as root parent
+    resp = api("GET", f"/space/{SPACE_KEY}?expand=homepage")
+    if not resp:
+        print("ERROR: Cannot access space OP")
+        sys.exit(1)
+    root_id = resp["homepage"]["id"]
+
+    # Phase 1: Create pages from spec files
+    spec_files = sorted(f for f in os.listdir(SPECS_DIR) if f.endswith(".md"))
+    print(f"Found {len(spec_files)} spec files")
+    print()
+
+    for spec_file in spec_files:
+        path = os.path.join(SPECS_DIR, spec_file)
+        with open(path, "r") as f:
+            content = f.read()
+
+        # Extract title from first heading
+        title_match = re.search(r'^#\s+(.+)', content, re.MULTILINE)
+        title = title_match.group(1) if title_match else spec_file.replace(".md", "")
+
+        # Create parent page for this spec
+        parent_id = create_page(title, md_to_storage(content), root_id)
+        if not parent_id:
+            continue
+        time.sleep(0.3)
+
+        # Create child pages from ## sections
+        sections = split_sections(content, level=2)
+        for sec_title, sec_body in sections:
+            if not sec_body.strip():
+                continue
+            child_id = create_page(
+                f"{title} — {sec_title}",
+                md_to_storage(sec_body),
+                parent_id
+            )
+            if child_id:
+                time.sleep(0.2)
+
+                # Create sub-pages from ### sections
+                subsections = split_sections(sec_body, level=3)
+                for sub_title, sub_body in subsections:
+                    if not sub_body.strip() or len(sub_body.strip()) < 50:
+                        continue
+                    create_page(
+                        f"{sec_title} — {sub_title}",
+                        md_to_storage(sub_body),
+                        child_id
+                    )
+                    time.sleep(0.2)
+
+    print(f"\nPhase 1 done: {created} pages from specs")
+
+    # Phase 2: Create additional topic pages to reach ~100
+    print("\nPhase 2: Creating additional topic pages...")
+    for topic_name, pages in EXTRA_TOPICS:
+        topic_id = create_page(topic_name, f"<p>Uebersicht: {h(topic_name)}</p>", root_id)
+        if not topic_id:
+            continue
+        time.sleep(0.3)
+
+        for page_title, page_content in pages:
+            create_page(
+                f"{topic_name} — {page_title}",
+                md_to_storage(page_content),
+                topic_id
+            )
+            time.sleep(0.2)
+
+    print(f"\nTotal pages created: {created}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/main/java/at/openaustria/confluencerag/ingestion/IngestionService.java
+++ b/src/main/java/at/openaustria/confluencerag/ingestion/IngestionService.java
@@ -4,6 +4,7 @@ import at.openaustria.confluencerag.config.ConfluenceProperties;
 import at.openaustria.confluencerag.config.IngestionProperties;
 import at.openaustria.confluencerag.crawler.CrawlerService;
 import at.openaustria.confluencerag.crawler.model.ConfluenceDocument;
+import at.openaustria.confluencerag.web.JobProgress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.document.Document;
@@ -15,6 +16,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.*;
+import java.util.function.Consumer;
 
 @Service
 public class IngestionService {
@@ -41,16 +43,27 @@ public class IngestionService {
     }
 
     public IngestionResult ingestAll() {
+        return ingestAll(p -> {});
+    }
+
+    public IngestionResult ingestAll(Consumer<JobProgress> onProgress) {
         Instant start = Instant.now();
+
+        onProgress.accept(new JobProgress("CRAWLING", "Crawle alle Spaces...",
+                0, 0, 0, 0, null));
+
         List<ConfluenceDocument> documents = crawlerService.crawlAll();
 
         log.info("Ingestion gestartet: {} Dokumente", documents.size());
         int chunksCreated = 0;
-        int chunksStored = 0;
         int errors = 0;
 
         List<Document> allChunks = new ArrayList<>();
-        for (ConfluenceDocument doc : documents) {
+        for (int i = 0; i < documents.size(); i++) {
+            ConfluenceDocument doc = documents.get(i);
+            onProgress.accept(new JobProgress("CHUNKING",
+                    String.format("Seite %d/%d — '%s'", i + 1, documents.size(), doc.title()),
+                    i + 1, documents.size(), chunksCreated, errors, doc.spaceKey()));
             try {
                 List<Document> chunks = chunkingService.chunkDocument(doc);
                 allChunks.addAll(chunks);
@@ -62,7 +75,7 @@ public class IngestionService {
         }
 
         log.info("Chunking: {} Dokumente → {} Chunks", documents.size(), chunksCreated);
-        chunksStored = storeBatched(allChunks);
+        int chunksStored = storeBatched(allChunks, onProgress, errors);
 
         Duration duration = Duration.between(start, Instant.now());
         log.info("Ingestion abgeschlossen: {} Chunks in {}s",
@@ -74,15 +87,27 @@ public class IngestionService {
     }
 
     public IngestionResult ingestSpace(String spaceKey) {
+        return ingestSpace(spaceKey, p -> {});
+    }
+
+    public IngestionResult ingestSpace(String spaceKey, Consumer<JobProgress> onProgress) {
         Instant start = Instant.now();
+
+        onProgress.accept(new JobProgress("CRAWLING",
+                String.format("Crawle Space %s...", spaceKey),
+                0, 0, 0, 0, spaceKey));
+
         List<ConfluenceDocument> documents = crawlerService.crawlSpace(spaceKey);
 
         int chunksCreated = 0;
-        int chunksStored = 0;
         int errors = 0;
 
         List<Document> allChunks = new ArrayList<>();
-        for (ConfluenceDocument doc : documents) {
+        for (int i = 0; i < documents.size(); i++) {
+            ConfluenceDocument doc = documents.get(i);
+            onProgress.accept(new JobProgress("CHUNKING",
+                    String.format("Seite %d/%d — '%s'", i + 1, documents.size(), doc.title()),
+                    i + 1, documents.size(), chunksCreated, errors, spaceKey));
             try {
                 List<Document> chunks = chunkingService.chunkDocument(doc);
                 allChunks.addAll(chunks);
@@ -93,7 +118,7 @@ public class IngestionService {
             }
         }
 
-        chunksStored = storeBatched(allChunks);
+        int chunksStored = storeBatched(allChunks, onProgress, errors);
 
         Duration duration = Duration.between(start, Instant.now());
         return new IngestionResult(1, documents.size(), chunksCreated, chunksStored, errors, duration);
@@ -102,11 +127,11 @@ public class IngestionService {
     public void ingestDocument(ConfluenceDocument doc) {
         List<Document> chunks = chunkingService.chunkDocument(doc);
         if (!chunks.isEmpty()) {
-            storeBatched(chunks);
+            storeBatched(chunks, p -> {}, 0);
         }
     }
 
-    private int storeBatched(List<Document> chunks) {
+    private int storeBatched(List<Document> chunks, Consumer<JobProgress> onProgress, int errors) {
         int stored = 0;
         for (int i = 0; i < chunks.size(); i += batchSize) {
             List<Document> batch = chunks.subList(i, Math.min(i + batchSize, chunks.size()));
@@ -124,6 +149,9 @@ public class IngestionService {
                         i, Math.min(i + batchSize, chunks.size()), e.getMessage());
                 stored += storeIndividually(batch);
             }
+            onProgress.accept(new JobProgress("STORING",
+                    String.format("%d/%d Chunks gespeichert", stored, chunks.size()),
+                    stored, chunks.size(), stored, errors, null));
         }
         return stored;
     }

--- a/src/main/java/at/openaustria/confluencerag/ingestion/SyncService.java
+++ b/src/main/java/at/openaustria/confluencerag/ingestion/SyncService.java
@@ -5,6 +5,7 @@ import at.openaustria.confluencerag.crawler.CrawlerService;
 import at.openaustria.confluencerag.crawler.client.ConfluenceClient;
 import at.openaustria.confluencerag.crawler.model.ConfluenceDocument;
 import at.openaustria.confluencerag.crawler.model.ConfluencePageResponse;
+import at.openaustria.confluencerag.web.JobProgress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.document.Document;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 @Service
@@ -46,6 +48,10 @@ public class SyncService {
     }
 
     public SyncResult syncAll() {
+        return syncAll(p -> {});
+    }
+
+    public SyncResult syncAll(Consumer<JobProgress> onProgress) {
         List<String> spaces = properties.spaces();
         if (spaces == null || spaces.isEmpty()) {
             log.warn("Keine Spaces konfiguriert.");
@@ -56,8 +62,13 @@ public class SyncService {
         int totalUpdated = 0, totalDeleted = 0, totalNew = 0, totalChunks = 0, totalErrors = 0;
         Instant start = Instant.now();
 
-        for (String spaceKey : spaces) {
-            SyncResult result = syncSpace(spaceKey);
+        for (int s = 0; s < spaces.size(); s++) {
+            String spaceKey = spaces.get(s);
+            onProgress.accept(new JobProgress("CRAWLING_CHANGES",
+                    String.format("Space %s (%d/%d)", spaceKey, s + 1, spaces.size()),
+                    s + 1, spaces.size(), totalChunks, totalErrors, spaceKey));
+
+            SyncResult result = syncSpace(spaceKey, onProgress);
             totalUpdated += result.pagesUpdated();
             totalDeleted += result.pagesDeleted();
             totalNew += result.pagesNew();
@@ -73,12 +84,16 @@ public class SyncService {
     }
 
     public SyncResult syncSpace(String spaceKey) {
+        return syncSpace(spaceKey, p -> {});
+    }
+
+    public SyncResult syncSpace(String spaceKey, Consumer<JobProgress> onProgress) {
         Instant start = Instant.now();
         Optional<Instant> lastSync = syncStateRepository.getLastSync(spaceKey);
 
         if (lastSync.isEmpty()) {
             log.info("Space {}: Erster Sync — Voll-Crawl wird durchgeführt", spaceKey);
-            IngestionResult result = ingestionService.ingestSpace(spaceKey);
+            IngestionResult result = ingestionService.ingestSpace(spaceKey, onProgress);
 
             // Save page IDs
             Set<String> pageIds = getCurrentPageIds(spaceKey);
@@ -94,11 +109,19 @@ public class SyncService {
         int updated = 0, deleted = 0, chunksCreated = 0, errors = 0;
 
         // 1. Get changed pages
+        onProgress.accept(new JobProgress("CRAWLING_CHANGES",
+                String.format("Space %s: Ermittle Änderungen...", spaceKey),
+                0, 0, 0, 0, spaceKey));
+
         List<ConfluenceDocument> changedDocs = crawlerService.crawlChangesSince(spaceKey, lastSync.get());
         log.info("Space {}: {} geänderte Seiten seit {}", spaceKey, changedDocs.size(), lastSync.get());
 
         // 2. Re-ingest changed pages
-        for (ConfluenceDocument doc : changedDocs) {
+        for (int i = 0; i < changedDocs.size(); i++) {
+            ConfluenceDocument doc = changedDocs.get(i);
+            onProgress.accept(new JobProgress("UPDATING",
+                    String.format("Seite %d/%d — '%s'", i + 1, changedDocs.size(), doc.title()),
+                    i + 1, changedDocs.size(), chunksCreated, errors, spaceKey));
             try {
                 deleteChunksForPage(String.valueOf(doc.pageId()));
                 List<Document> chunks = chunkingService.chunkDocument(doc);
@@ -114,12 +137,21 @@ public class SyncService {
         }
 
         // 3. Detect deleted pages
+        onProgress.accept(new JobProgress("DETECTING_DELETIONS",
+                String.format("Space %s: Prüfe gelöschte Seiten...", spaceKey),
+                0, 0, chunksCreated, errors, spaceKey));
+
         Set<String> currentPageIds = getCurrentPageIds(spaceKey);
         Set<String> knownPageIds = syncStateRepository.getKnownPageIds(spaceKey);
         Set<String> deletedPageIds = new HashSet<>(knownPageIds);
         deletedPageIds.removeAll(currentPageIds);
 
+        int deleteIndex = 0;
         for (String deletedId : deletedPageIds) {
+            deleteIndex++;
+            onProgress.accept(new JobProgress("DELETING",
+                    String.format("Lösche Seite %d/%d", deleteIndex, deletedPageIds.size()),
+                    deleteIndex, deletedPageIds.size(), chunksCreated, errors, spaceKey));
             try {
                 deleteChunksForPage(deletedId);
                 deleted++;

--- a/src/main/java/at/openaustria/confluencerag/web/AdminController.java
+++ b/src/main/java/at/openaustria/confluencerag/web/AdminController.java
@@ -21,7 +21,7 @@ public class AdminController {
     private final SyncStateRepository syncStateRepository;
 
     private final AtomicReference<JobStatus> currentJob = new AtomicReference<>(
-            new JobStatus("idle", null, null, null));
+            new JobStatus("idle", null, null, null, null));
 
     public AdminController(IngestionService ingestionService,
                            SyncService syncService,
@@ -36,14 +36,16 @@ public class AdminController {
         if (isRunning()) {
             return ResponseEntity.status(409).body(currentJob.get());
         }
-        currentJob.set(new JobStatus("running", "ingest", null, null));
+        String op = "ingest";
+        currentJob.set(new JobStatus("running", op, null, null, null));
+        var onProgress = progressCallback(op);
         CompletableFuture.runAsync(() -> {
             try {
-                IngestionResult result = ingestionService.ingestAll();
-                currentJob.set(new JobStatus("completed", "ingest", result, null));
+                IngestionResult result = ingestionService.ingestAll(onProgress);
+                currentJob.set(new JobStatus("completed", op, result, null, null));
                 log.info("Ingest abgeschlossen: {}", result);
             } catch (Exception e) {
-                currentJob.set(new JobStatus("failed", "ingest", null, e.getMessage()));
+                currentJob.set(new JobStatus("failed", op, null, e.getMessage(), null));
                 log.error("Ingest fehlgeschlagen", e);
             }
         });
@@ -55,13 +57,15 @@ public class AdminController {
         if (isRunning()) {
             return ResponseEntity.status(409).body(currentJob.get());
         }
-        currentJob.set(new JobStatus("running", "ingest:" + spaceKey, null, null));
+        String op = "ingest:" + spaceKey;
+        currentJob.set(new JobStatus("running", op, null, null, null));
+        var onProgress = progressCallback(op);
         CompletableFuture.runAsync(() -> {
             try {
-                IngestionResult result = ingestionService.ingestSpace(spaceKey);
-                currentJob.set(new JobStatus("completed", "ingest:" + spaceKey, result, null));
+                IngestionResult result = ingestionService.ingestSpace(spaceKey, onProgress);
+                currentJob.set(new JobStatus("completed", op, result, null, null));
             } catch (Exception e) {
-                currentJob.set(new JobStatus("failed", "ingest:" + spaceKey, null, e.getMessage()));
+                currentJob.set(new JobStatus("failed", op, null, e.getMessage(), null));
             }
         });
         return ResponseEntity.accepted().body(currentJob.get());
@@ -72,14 +76,16 @@ public class AdminController {
         if (isRunning()) {
             return ResponseEntity.status(409).body(currentJob.get());
         }
-        currentJob.set(new JobStatus("running", "sync", null, null));
+        String op = "sync";
+        currentJob.set(new JobStatus("running", op, null, null, null));
+        var onProgress = progressCallback(op);
         CompletableFuture.runAsync(() -> {
             try {
-                SyncResult result = syncService.syncAll();
-                currentJob.set(new JobStatus("completed", "sync", result, null));
+                SyncResult result = syncService.syncAll(onProgress);
+                currentJob.set(new JobStatus("completed", op, result, null, null));
                 log.info("Sync abgeschlossen: {}", result);
             } catch (Exception e) {
-                currentJob.set(new JobStatus("failed", "sync", null, e.getMessage()));
+                currentJob.set(new JobStatus("failed", op, null, e.getMessage(), null));
                 log.error("Sync fehlgeschlagen", e);
             }
         });
@@ -91,16 +97,22 @@ public class AdminController {
         if (isRunning()) {
             return ResponseEntity.status(409).body(currentJob.get());
         }
-        currentJob.set(new JobStatus("running", "sync:" + spaceKey, null, null));
+        String op = "sync:" + spaceKey;
+        currentJob.set(new JobStatus("running", op, null, null, null));
+        var onProgress = progressCallback(op);
         CompletableFuture.runAsync(() -> {
             try {
-                SyncResult result = syncService.syncSpace(spaceKey);
-                currentJob.set(new JobStatus("completed", "sync:" + spaceKey, result, null));
+                SyncResult result = syncService.syncSpace(spaceKey, onProgress);
+                currentJob.set(new JobStatus("completed", op, result, null, null));
             } catch (Exception e) {
-                currentJob.set(new JobStatus("failed", "sync:" + spaceKey, null, e.getMessage()));
+                currentJob.set(new JobStatus("failed", op, null, e.getMessage(), null));
             }
         });
         return ResponseEntity.accepted().body(currentJob.get());
+    }
+
+    private java.util.function.Consumer<JobProgress> progressCallback(String operation) {
+        return progress -> currentJob.set(new JobStatus("running", operation, null, null, progress));
     }
 
     @GetMapping("/job/status")
@@ -121,6 +133,7 @@ public class AdminController {
         String status,    // idle, running, completed, failed
         String operation, // ingest, sync, ingest:SPACEKEY, sync:SPACEKEY
         Object result,    // IngestionResult or SyncResult
-        String error
+        String error,
+        JobProgress progress // live progress during running state
     ) {}
 }

--- a/src/main/java/at/openaustria/confluencerag/web/JobProgress.java
+++ b/src/main/java/at/openaustria/confluencerag/web/JobProgress.java
@@ -1,0 +1,15 @@
+package at.openaustria.confluencerag.web;
+
+public record JobProgress(
+    String phase,
+    String detail,
+    int currentItem,
+    int totalItems,
+    int chunksProcessed,
+    int errors,
+    String currentSpace
+) {
+    public int percentComplete() {
+        return totalItems > 0 ? (currentItem * 100) / totalItems : 0;
+    }
+}

--- a/src/main/resources/static/css/app.css
+++ b/src/main/resources/static/css/app.css
@@ -269,6 +269,55 @@ html, body {
     color: var(--danger);
 }
 
+/* Job Progress */
+.job-progress {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+}
+.job-progress.hidden { display: none; }
+
+.job-progress-header {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 6px;
+    font-size: 0.85rem;
+}
+.job-progress-phase { font-weight: 600; }
+.job-progress-percent { color: var(--text-muted); }
+
+.progress-bar-container {
+    height: 8px;
+    background: var(--border);
+    border-radius: 4px;
+    overflow: hidden;
+}
+.progress-bar {
+    height: 100%;
+    background: var(--primary);
+    border-radius: 4px;
+    transition: width 0.3s ease;
+    width: 0%;
+}
+
+.job-progress-detail {
+    margin-top: 6px;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.job-progress-stats {
+    display: flex;
+    gap: 16px;
+    margin-top: 4px;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+}
+.job-progress-errors {
+    color: var(--danger);
+}
+
 .admin-global-actions {
     display: flex;
     gap: 8px;

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -22,6 +22,20 @@
                 <span>Admin</span>
                 <button id="admin-close" class="admin-close-btn">&#10005;</button>
             </div>
+            <div id="job-progress" class="job-progress hidden">
+                <div class="job-progress-header">
+                    <span id="job-progress-phase" class="job-progress-phase"></span>
+                    <span id="job-progress-percent" class="job-progress-percent"></span>
+                </div>
+                <div class="progress-bar-container">
+                    <div id="job-progress-bar" class="progress-bar"></div>
+                </div>
+                <div id="job-progress-detail" class="job-progress-detail"></div>
+                <div class="job-progress-stats">
+                    <span id="job-progress-chunks"></span>
+                    <span id="job-progress-errors"></span>
+                </div>
+            </div>
             <div id="admin-spaces" class="admin-spaces"></div>
             <div class="admin-global-actions">
                 <button id="sync-all-btn" class="admin-btn">Alle Spaces syncen</button>

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -170,13 +170,19 @@ async function startJob(url, label) {
 }
 
 async function pollJobStatus(label) {
+    showJobProgress(true);
     const poll = setInterval(async () => {
         try {
             const res = await fetch(`${API_BASE}/admin/job/status`);
             const job = await res.json();
 
+            if (job.status === 'running' && job.progress) {
+                updateJobProgress(job.progress);
+            }
+
             if (job.status === 'completed') {
                 clearInterval(poll);
+                showJobProgress(false);
                 setSyncing(false);
                 loadSyncStatus();
                 const r = job.result;
@@ -189,6 +195,7 @@ async function pollJobStatus(label) {
                 }
             } else if (job.status === 'failed') {
                 clearInterval(poll);
+                showJobProgress(false);
                 setSyncing(false);
                 loadSyncStatus();
                 showToast(`${label} fehlgeschlagen: ${job.error || 'Unbekannter Fehler'}`, 'error');
@@ -198,6 +205,38 @@ async function pollJobStatus(label) {
             // Netzwerkfehler beim Polling ignorieren, weiter versuchen
         }
     }, 3000);
+}
+
+function updateJobProgress(p) {
+    const phaseLabels = {
+        'CRAWLING': 'Crawling...',
+        'CHUNKING': 'Chunking...',
+        'STORING': 'Speichern...',
+        'CRAWLING_CHANGES': 'Aenderungen ermitteln...',
+        'UPDATING': 'Aktualisieren...',
+        'DETECTING_DELETIONS': 'Loeschungen erkennen...',
+        'DELETING': 'Loeschen...'
+    };
+
+    const pct = p.totalItems > 0 ? Math.round((p.currentItem * 100) / p.totalItems) : 0;
+    document.getElementById('job-progress-phase').textContent =
+        (p.currentSpace ? p.currentSpace + ': ' : '') + (phaseLabels[p.phase] || p.phase);
+    document.getElementById('job-progress-percent').textContent =
+        p.totalItems > 0 ? pct + '%' : '';
+    document.getElementById('job-progress-bar').style.width = pct + '%';
+    document.getElementById('job-progress-detail').textContent = p.detail || '';
+    document.getElementById('job-progress-chunks').textContent =
+        p.chunksProcessed > 0 ? p.chunksProcessed + ' Chunks' : '';
+    document.getElementById('job-progress-errors').textContent =
+        p.errors > 0 ? p.errors + ' Fehler' : '';
+}
+
+function showJobProgress(visible) {
+    document.getElementById('job-progress').classList.toggle('hidden', !visible);
+    // Auto-open admin panel when job starts
+    if (visible && adminPanel.classList.contains('hidden')) {
+        adminPanel.classList.remove('hidden');
+    }
 }
 
 function triggerSync() {


### PR DESCRIPTION
## Summary
- Live progress bar in Admin Panel during Ingest/Sync jobs showing phase, page/chunk counters, and error count
- New `JobProgress` record with `Consumer<JobProgress>` callback pattern — services report progress, controller updates `AtomicReference<JobStatus>`
- Frontend polls existing `/api/admin/job/status` endpoint (3s interval) and renders progress bar with phase labels, percentage, and detail text
- Includes analysis document, technical spec, and test data generation script (166 pages in OP space)

Closes #19

## Changes
- **`JobProgress.java`** — New record: phase, detail, currentItem, totalItems, chunksProcessed, errors, currentSpace
- **`AdminController.java`** — Extended `JobStatus` with `progress` field, wired callbacks to services
- **`IngestionService.java`** — Progress callbacks for CRAWLING → CHUNKING → STORING phases
- **`SyncService.java`** — Progress callbacks for CRAWLING_CHANGES → UPDATING → DETECTING_DELETIONS → DELETING phases
- **`index.html` / `app.css` / `app.js`** — Progress bar UI with auto-open admin panel
- **`docs/specs/12_*`** — Analysis and spec documents
- **`scripts/generate-test-pages.py`** — Generates ~166 test pages in Confluence OP space

## Test plan
- [x] `mvn clean compile` — succeeds
- [x] `mvn test` — all 36 tests pass
- [x] Manual test: Progress bar updates during OP space ingest (166 pages)
- [x] Progress bar disappears after completion, toast shows final result
- [x] SyncScheduler (cron) works unchanged (uses no-arg overloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)