### PR TITLE
Show active LLM model in header, default to gemma3:4b

### DIFF
--- a/src/main/java/at/openaustria/confluencerag/web/ChatController.java
+++ b/src/main/java/at/openaustria/confluencerag/web/ChatController.java
@@ -4,6 +4,7 @@ import at.openaustria.confluencerag.config.ConfluenceProperties;
 import at.openaustria.confluencerag.query.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.ServerSentEvent;
@@ -21,6 +22,12 @@ public class ChatController {
     private final QueryService queryService;
     private final ConfluenceProperties properties;
     private final ObjectMapper objectMapper;
+
+    @Value("${spring.ai.ollama.chat.model:gemma3:4b}")
+    private String chatModel;
+
+    @Value("${spring.ai.ollama.embedding.model:nomic-embed-text}")
+    private String embeddingModel;
 
     public ChatController(QueryService queryService,
                           ConfluenceProperties properties,
@@ -58,6 +65,14 @@ public class ChatController {
         );
 
         return Flux.concat(tokens, footer);
+    }
+
+    @GetMapping("/config")
+    public ResponseEntity<Map<String, String>> getConfig() {
+        return ResponseEntity.ok(Map.of(
+                "chatModel", chatModel,
+                "embeddingModel", embeddingModel
+        ));
     }
 
     @GetMapping("/spaces")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
       init:
         timeout: 60s
       chat:
-        model: ${OLLAMA_CHAT_MODEL:llama3}
+        model: ${OLLAMA_CHAT_MODEL:gemma3:4b}
         options:
           temperature: 0.3
       embedding:

--- a/src/main/resources/static/css/app.css
+++ b/src/main/resources/static/css/app.css
@@ -56,11 +56,29 @@ html, body {
     flex-shrink: 0;
 }
 
+.header-title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
 .header h1 {
     font-size: 1.1rem;
     font-weight: 600;
     white-space: nowrap;
 }
+
+.model-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    background: var(--badge-bg);
+    color: var(--badge-text);
+    white-space: nowrap;
+}
+.model-badge:empty { display: none; }
 
 .header-actions {
     display: flex;

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -9,7 +9,10 @@
 <body>
     <div class="app">
         <header class="header">
-            <h1>Confluence RAG Chat</h1>
+            <div class="header-title">
+                <h1>Confluence RAG Chat</h1>
+                <span id="model-badge" class="model-badge"></span>
+            </div>
             <div class="header-actions">
                 <div id="space-filter" class="space-filter"></div>
                 <button id="sync-btn" class="sync-btn" title="Confluence-Daten synchronisieren">Sync</button>

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -23,6 +23,7 @@ const ingestAllBtn = document.getElementById('ingest-all-btn');
 document.addEventListener('DOMContentLoaded', () => {
     loadSpaces();
     loadSyncStatus();
+    loadConfig();
     chatForm.addEventListener('submit', handleSubmit);
     syncBtn.addEventListener('click', () => triggerSync());
     adminToggle.addEventListener('click', toggleAdminPanel);
@@ -30,6 +31,18 @@ document.addEventListener('DOMContentLoaded', () => {
     syncAllBtn.addEventListener('click', () => triggerSync());
     ingestAllBtn.addEventListener('click', () => triggerIngest());
 });
+
+// ==================== Config ====================
+
+async function loadConfig() {
+    try {
+        const res = await fetch(`${API_BASE}/config`);
+        const config = await res.json();
+        document.getElementById('model-badge').textContent = config.chatModel || '';
+    } catch (e) {
+        console.error('Config konnte nicht geladen werden:', e);
+    }
+}
 
 // ==================== Spaces ====================
 


### PR DESCRIPTION
## Summary
- Model badge in header showing the active chat model (e.g. "gemma3:4b")
- New `GET /api/config` endpoint returning chatModel and embeddingModel
- Default chat model switched from llama3 to gemma3:4b

Closes #21

## Test plan
- [x] Badge shows correct model name in header
- [x] `/api/config` returns `{"chatModel":"gemma3:4b","embeddingModel":"nomic-embed-text"}`
- [x] `OLLAMA_CHAT_MODEL` env var override still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)