### PR TITLE
fix: Sync-Zeitpunkt zeigt 1970 statt korrektes Datum

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -131,7 +131,7 @@ function renderAdminSpaces(statusMap) {
     allSpaces.forEach(space => {
         const state = statusMap[space.key];
         const lastSync = state && state.lastSync
-            ? new Date(state.lastSync).toLocaleString('de-AT')
+            ? new Date(state.lastSync * 1000).toLocaleString('de-AT')
             : 'Noch nie';
         const pageCount = state && state.knownPageIds
             ? state.knownPageIds.length


### PR DESCRIPTION
## Summary

- Fix: `new Date(state.lastSync)` → `new Date(state.lastSync * 1000)` in `app.js`
- Java `Instant` serialisiert als Sekunden, JS `new Date()` erwartet Millisekunden

## Test plan

- [x] Code-Review: Einzeiler-Fix
- [ ] Manueller Test: Sync auslösen, Zeitpunkt im Admin-Panel prüfen

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)