### PR TITLE
fix: Mark RerankerService production constructor with @Autowired

### DIFF
--- a/src/main/java/at/openaustria/confluencerag/query/RerankerService.java
+++ b/src/main/java/at/openaustria/confluencerag/query/RerankerService.java
@@ -4,6 +4,7 @@ import at.openaustria.confluencerag.config.QueryProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.document.Document;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
@@ -26,6 +27,7 @@ public class RerankerService {
     private final QueryProperties.RerankerProperties config;
     private final RestClient restClient;
 
+    @Autowired
     public RerankerService(QueryProperties queryProperties) {
         this.config = queryProperties.reranker();
 


### PR DESCRIPTION
## Summary
- App startet nach #33 nicht mehr: `BeanCreationException: No default constructor found` für `RerankerService`
- Root cause: Zwei Konstruktoren (Production + Test) → Spring kann sich nicht entscheiden → fällt auf no-arg Suche zurück
- Fix: `@Autowired` am Production-Konstruktor markiert ihn eindeutig als DI-Ziel

Closes #36

## Test Plan
- [x] `RerankerServiceTest` (7/7) grün
- [x] Manuell verifiziert: App startet mit `QUERY_RERANKER_ENABLED=false`
- [ ] Manuell: App startet mit aktiviertem Reranker (sobald Container läuft)

🤖 Generated with [Claude Code](https://claude.com/claude-code)