### PR TITLE
chore: Add retrieval-quality-check script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,12 @@ Single Spring Boot 3.4.3 application with Spring AI 1.0.0. Three logical layers:
 - Auth supports both PAT (`Authorization: Bearer`) and Basic Auth (`username:password`) — configured via `ConfluenceProperties`
 - Configuration via `ConfluenceProperties` record (`@ConfigurationProperties(prefix = "confluence")`)
 
+## Diagnostic Scripts
+
+Utility scripts under `scripts/` — see `scripts/README.md` for details.
+
+- `retrieval-quality-check.py` — runs a set of test queries against the ingested Qdrant collection and prints per-query top matches with scores. Use when comparing embedding models, calibrating thresholds, or debugging "the sources are off" reports. No dependencies beyond Python 3 + running Ollama/Qdrant.
+
 ## Language Note
 
 Documentation is in German. Code uses English identifiers.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,76 @@
+# Scripts
+
+Utility-Skripte für Entwicklung, Testing und Diagnose. Nicht Teil der produktiven App, aber ins Repo eingecheckt damit sie wiederverwendbar sind.
+
+| Script | Zweck |
+|--------|-------|
+| `generate-test-pages.py` | Erzeugt synthetische Test-Seiten im lokalen Confluence-Container |
+| `retrieval-quality-check.py` | Führt Test-Queries gegen die Qdrant-Collection aus und prüft Scores/Top-Matches |
+
+---
+
+## `retrieval-quality-check.py`
+
+Diagnose-Script das eine feste Liste von Test-Queries gegen die laufende Qdrant-Collection schickt und die Top-K Treffer mit Similarity-Scores ausgibt. Hilft beim Vergleichen von Embedding-Modellen, Kalibrieren des Similarity-Thresholds und Spot-Checks nach Ingest-Änderungen.
+
+### Voraussetzungen
+
+- Ollama läuft auf `OLLAMA_URL` (default `http://localhost:11434`) und hat das Embedding-Modell verfügbar
+- Qdrant läuft auf `QDRANT_URL` (default `http://localhost:6333`) und hat die Collection ingestet
+- Python 3 (nur stdlib, keine extra Dependencies)
+
+### Benutzung
+
+```bash
+# Defaults: bge-m3 gegen localhost
+python3 scripts/retrieval-quality-check.py
+
+# Anderes Modell zum Vergleich (z.B. alter Stand mit nomic-embed-text)
+EMBED_MODEL=nomic-embed-text python3 scripts/retrieval-quality-check.py
+
+# Anderer Qdrant-Host / andere Collection
+QDRANT_URL=http://qdrant.prod:6333 COLLECTION=my-collection \
+  python3 scripts/retrieval-quality-check.py
+
+# Ad-hoc Einzel-Query von der Kommandozeile
+python3 scripts/retrieval-quality-check.py "Wie funktioniert X?"
+```
+
+### Environment-Variablen
+
+| Variable | Default | Bedeutung |
+|----------|---------|-----------|
+| `OLLAMA_URL` | `http://localhost:11434` | Ollama-Endpoint für Embeddings |
+| `QDRANT_URL` | `http://localhost:6333` | Qdrant-REST-Endpoint |
+| `COLLECTION` | `confluence-chunks` | Qdrant-Collection-Name |
+| `EMBED_MODEL` | `bge-m3` | Ollama-Embedding-Modell |
+| `TOP_K` | `10` | Anzahl der zurückgegebenen Treffer pro Query |
+
+### Test-Queries anpassen
+
+Die Queries sind oben im Script als `QUERIES`-Liste hart kodiert — zu jedem Query gehört ein Kommentar, was der erwartete Top-Treffer wäre. Für eigene Tests die Liste direkt im Script anpassen. Die Queries sind auf die Test-Daten der `openaustria-confluence-rag` Specs zugeschnitten und dienen als Beispiel.
+
+### Interpretation der Ausgabe
+
+Pro Query:
+- `top1` / `top10` — höchster und niedrigster Score in den Top-K
+- `spread` — Differenz (zeigt wie "eng" das Score-Band ist; bei Single-Domain-Corpora oft problematisch eng)
+- Numerierte Treffer-Liste mit Score, Space-Key und Titel
+
+**Faustregeln für bge-m3 auf deutschem Content:**
+- Relevanter Treffer: `> 0.50`
+- Off-topic: meist `< 0.45` (deshalb der Default-Threshold)
+- Spread unter `0.05`: Keyword-Heuristik oder Reranker helfen am meisten
+
+### Wann verwenden
+
+- Vor/nach Embedding-Modell-Wechsel → Before/After-Vergleich
+- Bei subjektivem Eindruck "die Quellen sind schlecht" → konkrete Daten holen
+- Nach Threshold-Änderungen in `application.yml`
+- Beim Evaluieren neuer Query-Formulierungen
+
+---
+
+## `generate-test-pages.py`
+
+Siehe Kommentar im Script.

--- a/scripts/retrieval-quality-check.py
+++ b/scripts/retrieval-quality-check.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Retrieval-Quality Check
+
+Runs a configurable set of test queries against the ingested Qdrant
+collection and prints per-query scores + top matches. Useful for:
+
+  - Comparing embedding models (e.g. nomic-embed-text vs bge-m3)
+  - Evaluating threshold settings
+  - Spot-checking retrieval quality after ingest changes
+  - Measuring the effect of reranker on/off (run app, compare output)
+
+Prerequisites:
+  - Ollama running on OLLAMA_URL with the embedding model loaded
+  - Qdrant running on QDRANT_URL with the ingested collection
+  - App has been ingested at least once
+
+Usage:
+  # With defaults (localhost, bge-m3, confluence-chunks collection)
+  python3 scripts/retrieval-quality-check.py
+
+  # Override model / URLs / collection
+  EMBED_MODEL=nomic-embed-text python3 scripts/retrieval-quality-check.py
+  OLLAMA_URL=http://localhost:11434 QDRANT_URL=http://localhost:6333 \
+    COLLECTION=confluence-chunks python3 scripts/retrieval-quality-check.py
+
+  # Ad-hoc single query
+  python3 scripts/retrieval-quality-check.py "Wie funktioniert X?"
+
+Edit the QUERIES list below to match your own content.
+"""
+
+import json
+import os
+import sys
+import urllib.request
+
+OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434")
+QDRANT_URL = os.getenv("QDRANT_URL", "http://localhost:6333")
+COLLECTION = os.getenv("COLLECTION", "confluence-chunks")
+EMBED_MODEL = os.getenv("EMBED_MODEL", "bge-m3")
+TOP_K = int(os.getenv("TOP_K", "10"))
+
+# (query_text, expected_top_match_hint)
+# Edit these to match your own corpus. The hint is just for human reading.
+QUERIES = [
+    ("Wie funktioniert der PlantUML Konverter?", "expect: Spec 03 / Issue #5"),
+    ("Spec 07", "expect: Spec 07 RAG Query Service"),
+    ("Wie wird die Qdrant Collection konfiguriert?", "expect: ADR-002 / Issue #1 / #2"),
+    ("Backup und Recovery", "expect: Betriebshandbuch — Backup"),
+    ("Welche Endpunkte hat die Admin API?", "expect: API-Dokumentation — Admin API"),
+    ("Was ist CORS?", "expect: Issue #12 CORS"),
+    ("Wie backe ich einen Apfelkuchen?", "expect: nothing relevant (off-topic sanity check)"),
+]
+
+
+def embed(text: str) -> list:
+    req = urllib.request.Request(
+        f"{OLLAMA_URL}/api/embed",
+        data=json.dumps({"model": EMBED_MODEL, "input": text}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req) as r:
+        return json.loads(r.read())["embeddings"][0]
+
+
+def search(vector: list, top: int) -> list:
+    req = urllib.request.Request(
+        f"{QDRANT_URL}/collections/{COLLECTION}/points/search",
+        data=json.dumps({"vector": vector, "limit": top, "with_payload": True}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req) as r:
+        return json.loads(r.read())["result"]
+
+
+def run(query: str, expect: str = "") -> None:
+    print(f"\n=== Query: {query!r}")
+    if expect:
+        print(f"    ({expect})")
+    vector = embed(query)
+    hits = search(vector, TOP_K)
+    if not hits:
+        print("   (no hits)")
+        return
+    scores = [h["score"] for h in hits]
+    spread = scores[0] - scores[-1]
+    print(f"   top1={scores[0]:.4f}  top{TOP_K}={scores[-1]:.4f}  spread={spread:.4f}")
+    for i, h in enumerate(hits):
+        payload = h.get("payload", {})
+        title = payload.get("pageTitle", "?")
+        space = payload.get("spaceKey", "?")
+        print(f"   {i+1:2}. {h['score']:.4f}  [{space}] {title[:80]}")
+
+
+def main() -> None:
+    print(f"# retrieval-quality-check")
+    print(f"#   ollama:     {OLLAMA_URL}")
+    print(f"#   qdrant:     {QDRANT_URL}/{COLLECTION}")
+    print(f"#   embed:      {EMBED_MODEL}")
+    print(f"#   top_k:      {TOP_K}")
+
+    if len(sys.argv) > 1:
+        # Ad-hoc single query from CLI
+        run(" ".join(sys.argv[1:]))
+        return
+
+    for query, expect in QUERIES:
+        run(query, expect)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `scripts/retrieval-quality-check.py` — Python diagnostic script that runs test queries against the ingested Qdrant collection and prints per-query top-K scores. Used during the bge-m3 rollout to verify retrieval precision.
- Add `scripts/README.md` documenting all utility scripts under `scripts/`
- Pointer in `CLAUDE.md`

## Why
When the user reports "the sources are off" we want concrete data instead of subjective judgement. This script lets anyone run the same query set and see scores. Useful for:
- Before/after comparison when changing embedding models
- Calibrating `query.similarity-threshold`
- Spot-checking after ingest changes

## Test Plan
- [x] Syntax check passes
- [x] Runs against local setup (bge-m3 + Qdrant)
- [x] Ad-hoc single-query mode works: `python3 scripts/retrieval-quality-check.py "PlantUML"`
- [x] Env-var overrides documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)