### PR TITLE
feat: LLM-based listwise reranker via Ollama with pluggable interface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,18 +18,20 @@ mvn test -pl . -Dtest=ConfluenceHtmlConverterTest     # Run converter tests
 ## Running Locally
 
 ```bash
-# Infrastructure (Qdrant + Ollama + Reranker)
-docker compose up -d qdrant ollama reranker
+# Infrastructure (Qdrant + Ollama)
+docker compose up -d qdrant ollama
 
-# First-time setup: pull embedding model (1.2 GB)
+# First-time setup: pull embedding model (1.2 GB) and a small LLM for reranking
 docker exec openaustria-confluence-rag-ollama-1 ollama pull bge-m3
+docker exec openaustria-confluence-rag-ollama-1 ollama pull qwen3:0.6b   # default reranker model
 
 # App with Basic Auth (local Confluence test, default chat model: gemma3:4b, embedding: bge-m3)
 CONFLUENCE_USERNAME=admin CONFLUENCE_PASSWORD=admin CONFLUENCE_SPACES=ds,OP \
   mvn spring-boot:run -DskipTests
 
-# Reranker can be disabled if container is not running
-QUERY_RERANKER_ENABLED=false mvn spring-boot:run -DskipTests
+# Switch reranker mode (default is llm)
+QUERY_RERANKER_TYPE=none mvn spring-boot:run -DskipTests        # disable reranking
+QUERY_RERANKER_TYPE=infinity mvn spring-boot:run -DskipTests    # use external infinity container
 
 # Local Confluence test instance
 docker compose -f docker-compose.test.yml up -d      # Confluence 8.5 on port 8090
@@ -43,7 +45,12 @@ Single Spring Boot 3.4.3 application with Spring AI 1.0.0. Three logical layers:
 
 2. **Ingestion** (`ingestion/`) — `ChunkingService` (TokenTextSplitter, 500 token/50 overlap) → `IngestionService` (parallel batch upsert to Qdrant, 50/batch, 2 threads, 1024-dim vectors for `bge-m3`) → `SyncService` (CQL delta queries, deleted page detection, JSON state file) → `SyncScheduler` (cron, disabled by default). Chunk deletion uses `QdrantClient.deleteAsync(filter)` directly (not `VectorStore.delete()` which only accepts IDs). Vector dimension is configurable via `ingestion.vector-dimension`.
 
-3. **Query** (`query/`) — `QueryService` (similarity search → cross-encoder rerank via `RerankerService` → context build → Ollama ChatClient) with space filtering via Qdrant FilterExpression. Streaming via `Flux<String>`. `RerankerService` calls an external `michaelf34/infinity` container hosting `BAAI/bge-reranker-v2-m3`; falls back to vector order on errors and is toggleable via `query.reranker.enabled`.
+3. **Query** (`query/`) — `QueryService` (similarity search → reranker → context build → Ollama ChatClient) with space filtering via Qdrant FilterExpression. Streaming via `Flux<String>`. Reranking is pluggable via the `Reranker` interface with three implementations selected at startup via `@ConditionalOnProperty`:
+   - `LlmListwiseReranker` (default, `query.reranker.type=llm`) — sends top-N candidates to a small Ollama LLM (default `qwen3:0.6b`) in a single listwise prompt, parses JSON-array output. No extra container needed.
+   - `InfinityCrossEncoderReranker` (`type=infinity`) — calls external `michaelf34/infinity` container hosting `BAAI/bge-reranker-v2-m3`. Higher precision, requires the ~4.5 GB image.
+   - `NoOpReranker` (`type=none`) — pass-through, vector order only.
+
+   All three fall back to vector order on errors. `QueryService` depends only on the `Reranker` interface.
 
 **Web layer** (`web/`) — `ChatController` (POST /api/chat, POST /api/chat/stream SSE, GET /api/spaces), `AdminController` (ingest/sync triggers). Frontend is vanilla HTML/CSS/JS in `src/main/resources/static/`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,10 @@ services:
       OLLAMA_BASE_URL: http://ollama:11434
       QDRANT_HOST: qdrant
       QDRANT_GRPC_PORT: 6334
-      QUERY_RERANKER_URL: http://reranker:7997
+      # Reranker default ist 'llm' (nutzt Ollama, kein extra Container).
+      # Für die Infinity-Variante: QUERY_RERANKER_TYPE=infinity setzen und
+      # QUERY_RERANKER_INFINITY_URL=http://reranker:7997, plus den reranker-Service unten einkommentieren.
+      QUERY_RERANKER_LLM_URL: http://ollama:11434
       SYNC_STATE_FILE: /app/data/sync-state.json
     volumes:
       - app_data:/app/data
@@ -18,8 +21,6 @@ services:
       qdrant:
         condition: service_healthy
       ollama:
-        condition: service_started
-      reranker:
         condition: service_started
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
@@ -58,17 +59,22 @@ services:
     #           count: all
     #           capabilities: [gpu]
 
-  reranker:
-    image: michaelf34/infinity:latest
-    ports:
-      - "7997:7997"
-    command: ["v2", "--model-id", "BAAI/bge-reranker-v2-m3", "--port", "7997"]
-    volumes:
-      - reranker_cache:/app/.cache
-    restart: unless-stopped
+  # Optionaler Cross-Encoder Reranker (Alternative zum Default-LLM-Reranker).
+  # Aktivieren via QUERY_RERANKER_TYPE=infinity. Image ist groß (~4.5 GB),
+  # nur sinnvoll wenn Docker Hub bzw. ein Mirror-Image verfügbar ist.
+  # Auf Zielsystemen mit privater Registry: vorher in die eigene Registry pushen.
+  #
+  # reranker:
+  #   image: michaelf34/infinity:latest
+  #   ports:
+  #     - "7997:7997"
+  #   command: ["v2", "--model-id", "BAAI/bge-reranker-v2-m3", "--port", "7997"]
+  #   volumes:
+  #     - reranker_cache:/app/.cache
+  #   restart: unless-stopped
 
 volumes:
   app_data:
   qdrant_data:
   ollama_data:
-  reranker_cache:
+  # reranker_cache:

--- a/docs/specs/16_cross-encoder-reranker-spec.md
+++ b/docs/specs/16_cross-encoder-reranker-spec.md
@@ -1,7 +1,13 @@
 # Spec: Cross-Encoder Reranker
 
+> **⚠️ SUPERSEDED durch [Spec 18: LLM-basiertes Listwise-Reranking](18_llm-listwise-reranker-spec.md) (2026-04-11)**
+>
+> Diese Spec hat einen externen `michaelf34/infinity` Container vorgesehen. Auf den produktiven Zielsystemen ist Docker Hub gesperrt und das Image (~4.5 GB) ist nicht zuverlässig pullbar. Spec 18 ersetzt diesen Ansatz durch LLM-basiertes Listwise-Reranking via Ollama (kein neuer Container, kein Hub-Zugriff).
+>
+> Der hier spezifizierte Code aus PR #35 wird **nicht entfernt**, sondern als alternative Implementierung (`InfinityCrossEncoderReranker`, aktivierbar via `query.reranker.type=infinity`) erhalten — siehe Spec 18.
+
 **Datum:** 2026-04-09
-**Status:** Spec
+**Status:** Superseded by Spec 18
 **Betroffene Dateien:**
 - `src/main/java/at/openaustria/confluencerag/query/QueryService.java`
 - `src/main/java/at/openaustria/confluencerag/query/RerankerService.java` (**neu**)

--- a/docs/specs/17_retrieval-quality-improvement-options.md
+++ b/docs/specs/17_retrieval-quality-improvement-options.md
@@ -50,11 +50,17 @@ Wechsel von `nomic-embed-text` (768 dim, Englisch-optimiert) auf `bge-m3` (1024 
 - Bei abstrakten / kompositorischen Queries bleibt der Spread eng (0.04–0.06) — das Single-Domain-Problem ist nicht verschwunden, nur abgemildert
 - Titel-exakte Treffer werden manchmal von thematisch umgebenden Seiten überranked (Admin API, CORS) → Cross-Encoder würde hier helfen
 
-### 2.2 Cross-Encoder Reranker (PR #35, Code fertig)
+### 2.2 Cross-Encoder Reranker (PR #35, Code als alternative Implementierung)
 
-`RerankerService` ruft einen externen `michaelf34/infinity` Container mit `BAAI/bge-reranker-v2-m3` auf. Hat sauberen Fallback auf Vektor-Reihenfolge bei HTTP-Fehlern oder wenn deaktiviert (`query.reranker.enabled=false`).
+`RerankerService` rief ursprünglich einen externen `michaelf34/infinity` Container mit `BAAI/bge-reranker-v2-m3` auf (Spec 16).
 
-Aktuell mangels Docker-Netzwerk nicht deployed — Code ist aber getestet (7 Unit-Tests) und gemerged.
+**Architektur-Pivot 2026-04-11 (Spec 18, PR #40):** Auf den produktiven Zielsystemen ist Docker Hub gesperrt und das Image (~4.5 GB) ist nicht zuverlässig pullbar. Die Anforderung lautet "Reranker unter eigener Kontrolle". Konsequenz:
+
+- **Neuer Default:** `LlmListwiseReranker` — nutzt Ollama mit einem kleinen LLM (qwen3:0.6b o.ä.) für Listwise-Reranking in einem einzigen Call. Kein neuer Container, keine Hub-Abhängigkeit.
+- **Alte Implementierung erhalten:** Der Infinity-Code wurde nicht weggeworfen, sondern als `InfinityCrossEncoderReranker` über das neue `Reranker`-Interface erreichbar gemacht. Aktivierbar via `query.reranker.type=infinity` für Umgebungen wo der Container verfügbar ist.
+- **Drittes Mode:** `NoOpReranker` (`type=none`) als sauberer Disable-Pfad ohne Wenn-Abfragen.
+
+Bean-Auswahl beim Start via `@ConditionalOnProperty`. `QueryService` injiziert nur das Interface und weiß nicht welche Implementierung aktiv ist.
 
 ---
 

--- a/docs/specs/18_llm-listwise-reranker-spec.md
+++ b/docs/specs/18_llm-listwise-reranker-spec.md
@@ -1,0 +1,451 @@
+# Spec: LLM-basiertes Listwise-Reranking via Ollama
+
+**Datum:** 2026-04-11
+**Status:** Spec
+**Bezug:** [16_cross-encoder-reranker-spec.md](16_cross-encoder-reranker-spec.md) (wird durch diesen Spec abgelöst, Code bleibt aber als alternative Implementierung erhalten)
+**Roadmap:** [17_retrieval-quality-improvement-options.md](17_retrieval-quality-improvement-options.md)
+
+**Betroffene Dateien:**
+- `src/main/java/at/openaustria/confluencerag/query/Reranker.java` (**neu**, Interface)
+- `src/main/java/at/openaustria/confluencerag/query/LlmListwiseReranker.java` (**neu**)
+- `src/main/java/at/openaustria/confluencerag/query/NoOpReranker.java` (**neu**)
+- `src/main/java/at/openaustria/confluencerag/query/RerankerService.java` → wird zu `InfinityCrossEncoderReranker.java` (rename + Interface implementieren)
+- `src/main/java/at/openaustria/confluencerag/query/QueryService.java` (Depends on `Reranker`-Interface)
+- `src/main/java/at/openaustria/confluencerag/config/QueryProperties.java` (Erweitert um `type` und per-Type Properties)
+- `src/main/resources/application.yml` (neue Config-Struktur)
+- `docker-compose.yml` (Reranker-Service als optionaler Block kommentiert)
+- `src/test/java/at/openaustria/confluencerag/query/LlmListwiseRerankerTest.java` (**neu**)
+- `src/test/java/at/openaustria/confluencerag/query/InfinityCrossEncoderRerankerTest.java` (umbenannt aus `RerankerServiceTest.java`)
+- `CLAUDE.md`
+
+---
+
+## 1. Motivation & Architektur-Pivot
+
+### 1.1 Warum nicht (mehr) Infinity?
+
+Spec 16 hat einen Cross-Encoder-Reranker basierend auf einem externen `michaelf34/infinity` Container vorgesehen. Im Test-Setup hat sich gezeigt:
+
+1. **Image-Größe ist 4.5 GB** (CUDA + PyTorch-Stack) — auf einer instabilen Verbindung praktisch nicht zuverlässig zu pullen
+2. **Auf den produktiven Zielsystemen ist Docker Hub gesperrt** — nur eine private Docker Registry ist erreichbar
+3. **Anforderung: Reranker unter eigener Kontrolle** — kein Drittanbieter-Service, kein externes Image, kein Hub-Vendoring
+
+### 1.2 Lösung: LLM-basiertes Listwise-Reranking
+
+Ollama läuft auf allen Zielsystemen ohnehin (für Embeddings und Chat). Statt ein dediziertes Cross-Encoder-Modell zu betreiben, nutzen wir ein bereits verfügbares kleines LLM (`qwen3:0.6b` o.ä.) als Reranker. Das LLM bekommt in **einem einzigen Call** alle Kandidaten als nummerierte Liste und gibt die Top-K als JSON-Array zurück.
+
+**Vorteile gegenüber Infinity:**
+- **Null neue Software** — nutzt bestehendes Ollama
+- **Null neue Container** — kein Image-Pull, kein Hub-Zugriff
+- **Voll unter eigener Kontrolle** — Modell läuft im selben Ollama-Prozess wie Embeddings/Chat
+- Modell-Wahl pro Deployment konfigurierbar ohne Code-Änderung
+
+**Trade-offs:**
+- Qualität liegt bei ca. 70–85% eines echten Cross-Encoders (statt 95%+) — aber immer noch deutlich besser als die alte Keyword-Heuristik und besser als rohe Vektor-Reihenfolge
+- Latenz: 1–3 Sekunden zusätzlich pro Query (ein LLM-Call) statt 200–800 ms (Cross-Encoder-Container)
+- LLMs können halluzinieren → Robustheit beim JSON-Parsing wichtig
+
+### 1.3 Bestehender Code wird nicht weggeworfen
+
+Die Infinity-Implementierung aus PR #35 wird **nicht entfernt**, sondern in das neue Interface integriert. Beide Reranker sind über die Konfiguration auswählbar:
+
+- `query.reranker.type=llm` (Default) — LLM-Listwise via Ollama
+- `query.reranker.type=infinity` — Infinity-Cross-Encoder (für Umgebungen wo der Container verfügbar ist)
+- `query.reranker.type=none` — kein Rerank, Vektor-Reihenfolge
+
+So bleibt der Aufwand aus #33/#35 nutzbar und das Setup ist zukunftssicher.
+
+---
+
+## 2. Interface & Bean-Selection
+
+### 2.1 `Reranker` Interface
+
+Neue Datei: `src/main/java/at/openaustria/confluencerag/query/Reranker.java`
+
+```java
+package at.openaustria.confluencerag.query;
+
+import org.springframework.ai.document.Document;
+import java.util.List;
+
+/**
+ * Reordering strategy applied to vector-search candidates before they
+ * are passed to the LLM as context. Implementations choose how to
+ * compute relevance scores (LLM listwise, cross-encoder, no-op, ...).
+ */
+public interface Reranker {
+
+    /**
+     * Re-rank the given candidates and return the top {@code topK}
+     * documents in new order. Implementations must fall back to the
+     * original order on any error to keep the query path safe.
+     */
+    List<Document> rerank(String query, List<Document> candidates, int topK);
+
+    /**
+     * Number of candidates the QueryService should fetch from Qdrant
+     * before passing them to this reranker. Implementations have
+     * different sweet spots: LLMs are limited by context window,
+     * cross-encoders can handle more.
+     */
+    int candidateCount();
+}
+```
+
+### 2.2 Drei Bean-Implementierungen
+
+Alle drei sind `@Service` annotiert, aber durch `@ConditionalOnProperty` ist immer **genau einer** aktiv:
+
+| Implementierung | Aktivierung | Default |
+|-----------------|-------------|---------|
+| `LlmListwiseReranker` | `query.reranker.type=llm` | ✅ (`matchIfMissing=true`) |
+| `InfinityCrossEncoderReranker` | `query.reranker.type=infinity` | nein |
+| `NoOpReranker` | `query.reranker.type=none` | nein |
+
+```java
+@Service
+@ConditionalOnProperty(prefix = "query.reranker", name = "type",
+        havingValue = "llm", matchIfMissing = true)
+public class LlmListwiseReranker implements Reranker { ... }
+
+@Service
+@ConditionalOnProperty(prefix = "query.reranker", name = "type",
+        havingValue = "infinity")
+public class InfinityCrossEncoderReranker implements Reranker { ... }
+
+@Service
+@ConditionalOnProperty(prefix = "query.reranker", name = "type",
+        havingValue = "none")
+public class NoOpReranker implements Reranker { ... }
+```
+
+`QueryService` injiziert dann nur `Reranker` (das Interface) und weiß nicht welche Implementierung aktiv ist.
+
+---
+
+## 3. Configuration Model
+
+### 3.1 `QueryProperties` Refactoring
+
+```java
+@ConfigurationProperties(prefix = "query")
+public record QueryProperties(
+    int topK,
+    double similarityThreshold,
+    RerankerProperties reranker
+) {
+    public record RerankerProperties(
+        String type,                           // llm | infinity | none
+        LlmRerankerProperties llm,
+        InfinityRerankerProperties infinity
+    ) {}
+
+    public record LlmRerankerProperties(
+        String baseUrl,                        // Ollama base URL
+        String model,                          // e.g. qwen3:0.6b
+        int candidateCount,                    // chunks pro Rerank-Call
+        int timeoutSeconds,
+        int maxChunkChars                      // pro Chunk im Prompt
+    ) {}
+
+    public record InfinityRerankerProperties(
+        String baseUrl,
+        String model,
+        int candidateCount,
+        int timeoutSeconds
+    ) {}
+}
+```
+
+Das alte `enabled`-Feld entfällt — `type=none` ersetzt es semantisch sauberer.
+
+### 3.2 `application.yml`
+
+```yaml
+query:
+  top-k: ${QUERY_TOP_K:5}
+  similarity-threshold: ${QUERY_SIMILARITY_THRESHOLD:0.45}
+  reranker:
+    type: ${QUERY_RERANKER_TYPE:llm}              # llm | infinity | none
+    llm:
+      base-url: ${QUERY_RERANKER_LLM_URL:http://localhost:11434}
+      model: ${QUERY_RERANKER_LLM_MODEL:qwen3:0.6b}
+      candidate-count: ${QUERY_RERANKER_LLM_CANDIDATES:15}
+      timeout-seconds: ${QUERY_RERANKER_LLM_TIMEOUT:60}
+      max-chunk-chars: ${QUERY_RERANKER_LLM_MAX_CHUNK:500}
+    infinity:
+      base-url: ${QUERY_RERANKER_INFINITY_URL:http://localhost:7997}
+      model: ${QUERY_RERANKER_INFINITY_MODEL:BAAI/bge-reranker-v2-m3}
+      candidate-count: ${QUERY_RERANKER_INFINITY_CANDIDATES:30}
+      timeout-seconds: ${QUERY_RERANKER_INFINITY_TIMEOUT:10}
+```
+
+---
+
+## 4. `LlmListwiseReranker` Implementierung
+
+### 4.1 Prompt-Design
+
+Listwise mit JSON-Array Ausgabe — bewährte Methode in der Literatur (RankGPT):
+
+```
+Du bist ein Such-Assistent. Bewerte die Relevanz folgender Dokument-Auszüge
+für die Frage.
+
+Frage: "{query}"
+
+Dokumente:
+[1] Titel: {title}
+{content_truncated_to_500_chars}
+
+[2] Titel: {title}
+{content_truncated_to_500_chars}
+
+...
+
+[N] Titel: {title}
+{content_truncated_to_500_chars}
+
+Gib die Nummern der {topK} relevantesten Dokumente in absteigender Relevanz
+als JSON-Array zurück. Beispiel: [3, 7, 1, 12, 5]
+
+Antworte AUSSCHLIESSLICH mit dem Array. Keine Erklärung, kein Markdown,
+keine Klammern oder Anführungszeichen drumherum. Nur das Array.
+```
+
+### 4.2 Inferenz-Flow
+
+```java
+public List<Document> rerank(String query, List<Document> candidates, int topK) {
+    if (candidates.isEmpty()) return List.of();
+    if (candidates.size() <= topK) return candidates;
+
+    try {
+        String prompt = buildPrompt(query, candidates, topK);
+        String response = callOllama(prompt);  // POST /api/generate
+        List<Integer> ranking = parseJsonArray(response);
+        return mapToDocuments(ranking, candidates, topK);
+    } catch (Exception e) {
+        log.warn("LLM-Rerank fehlgeschlagen, fallback auf Vektor-Reihenfolge: {}",
+                 e.getMessage());
+        return candidates.stream().limit(topK).toList();
+    }
+}
+```
+
+### 4.3 Robustheits-Anforderungen
+
+1. **JSON-Parse-Fallback**: Wenn das LLM Markdown-Wrap, Erklärungstext oder kaputtes JSON liefert, mit Regex das erste `[...]`-Array extrahieren und parsen
+2. **Index-Validierung**: Nur Indices `1 ≤ i ≤ N` akzeptieren, Duplikate entfernen
+3. **Auffüllen**: Wenn das LLM weniger als `topK` Indices liefert, mit den fehlenden Original-Top-Kandidaten auffüllen
+4. **Truncation**: Jeder Chunk auf `maxChunkChars` (Default 500) gekürzt damit der Prompt im Context-Window bleibt
+5. **Stop-Token**: `temperature=0`, `top_p=0.1`, `num_predict=64` für deterministische, kurze Antworten
+6. **Timeout-Fallback**: Bei Timeout sauber auf Vektor-Reihenfolge zurückfallen
+
+### 4.4 Ollama API Call
+
+Direkt über `RestClient` (kein Spring AI ChatClient — der ist für die Antwort-Generierung reserviert):
+
+```java
+POST {baseUrl}/api/generate
+{
+  "model": "qwen3:0.6b",
+  "prompt": "...",
+  "stream": false,
+  "options": {
+    "temperature": 0,
+    "top_p": 0.1,
+    "num_predict": 64
+  }
+}
+```
+
+Response:
+```json
+{
+  "model": "qwen3:0.6b",
+  "response": "[3, 7, 1, 12, 5]",
+  ...
+}
+```
+
+---
+
+## 5. `NoOpReranker`
+
+Trivial — gibt die ersten `topK` Kandidaten unverändert zurück. Wird nur aktiv wenn `query.reranker.type=none`. Vorteil gegenüber dem alten `enabled=false`-Pattern: keine Wenn-Abfrage in jedem Bean, sauberes Single-Responsibility.
+
+```java
+@Service
+@ConditionalOnProperty(prefix = "query.reranker", name = "type", havingValue = "none")
+public class NoOpReranker implements Reranker {
+
+    private final int candidateCount;
+
+    public NoOpReranker(QueryProperties properties) {
+        // Use top-k as candidate count when no reranking happens
+        this.candidateCount = properties.topK();
+    }
+
+    @Override
+    public List<Document> rerank(String query, List<Document> candidates, int topK) {
+        return candidates.stream().limit(topK).toList();
+    }
+
+    @Override
+    public int candidateCount() {
+        return candidateCount;
+    }
+}
+```
+
+---
+
+## 6. `InfinityCrossEncoderReranker` (Rename + Interface)
+
+Die bestehende `RerankerService.java` wird:
+1. Umbenannt zu `InfinityCrossEncoderReranker.java`
+2. `implements Reranker` hinzugefügt
+3. `@ConditionalOnProperty` für `type=infinity` ergänzt
+4. Konfiguration liest aus `properties.reranker().infinity()` statt der bisherigen flachen Struktur
+5. Das `enabled`-Handling entfällt (wird durch Bean-Selection ersetzt)
+6. Test-Datei wird entsprechend umbenannt
+
+Die HTTP-Logik, Fallback-Logik und Tests bleiben unverändert.
+
+---
+
+## 7. `QueryService` Anpassung
+
+Statt `RerankerService` injiziert `QueryService` jetzt das `Reranker`-Interface:
+
+```java
+private final Reranker reranker;
+
+public QueryService(VectorStore vectorStore, ChatClient.Builder chatClientBuilder,
+                    QueryProperties queryProperties, Reranker reranker) {
+    // ...
+    this.reranker = reranker;
+}
+
+private List<Document> searchRelevantDocs(QueryRequest request) {
+    int fetchK = Math.max(queryProperties.topK(), reranker.candidateCount());
+    // ... search wie bisher
+    List<Document> candidates = vectorStore.similaritySearch(searchBuilder.build());
+    return reranker.rerank(request.question(), candidates, queryProperties.topK());
+}
+```
+
+`QueryService` muss nicht wissen welche Reranker-Implementierung aktiv ist. Spring sorgt dafür dass genau eine vorhanden ist.
+
+---
+
+## 8. `docker-compose.yml`
+
+Der `reranker`-Service-Block bleibt im File, aber wird **auskommentiert** mit Hinweis darauf dass der Default-LLM-Reranker (Option llm) keinen Container braucht. Wer den Infinity-Pfad nutzen will, kommentiert den Block ein und setzt `QUERY_RERANKER_TYPE=infinity`.
+
+```yaml
+# Optional: dedizierter Cross-Encoder Reranker (alternative zum Default-LLM-Reranker).
+# Aktiviert via QUERY_RERANKER_TYPE=infinity. Image ist groß (~4.5 GB), nur sinnvoll
+# wenn Docker Hub bzw. das Mirror-Image verfügbar ist.
+#
+#  reranker:
+#    image: michaelf34/infinity:latest
+#    ports:
+#      - "7997:7997"
+#    command: ["v2", "--model-id", "BAAI/bge-reranker-v2-m3", "--port", "7997"]
+#    volumes:
+#      - reranker_cache:/app/.cache
+#    restart: unless-stopped
+```
+
+Auch das `depends_on: reranker` im `app`-Service wird entfernt — die App soll auch starten wenn kein Reranker-Container läuft (bei `type=llm` oder `type=none` braucht sie ihn nicht).
+
+---
+
+## 9. Tests
+
+### 9.1 Neue Tests: `LlmListwiseRerankerTest`
+
+Pro Szenario ein Test mit eingebettetem `HttpServer` der die Ollama-API mockt (gleiche Pattern wie der existierende Reranker-Test):
+
+1. **Happy path** — Ollama liefert sauberes JSON-Array → Reihenfolge korrekt
+2. **JSON in Markdown wrap** — Ollama liefert ` ```json\n[3,1,2]\n``` ` → Parser extrahiert das Array trotzdem
+3. **JSON mit Erklärung davor** — Ollama liefert "Hier sind die Ergebnisse: [3,1,2]" → wird trotzdem geparst
+4. **Out-of-range Index** — Ollama liefert `[99, 1, 2]` → 99 wird verworfen
+5. **Duplikate** — Ollama liefert `[1, 1, 2]` → Duplikat verworfen
+6. **Zu wenige Indices** — Ollama liefert `[3]` aber topK=5 → wird mit Original-Top aufgefüllt
+7. **HTTP-Fehler** — Ollama 500 → Fallback auf Vektor-Reihenfolge
+8. **Timeout** — Mock blockiert > Timeout → Fallback
+9. **Komplett kaputtes JSON** — Ollama liefert "lorem ipsum" → Fallback
+10. **Leere Kandidaten-Liste** → leere Liste zurück
+11. **Weniger Kandidaten als topK** → unverändert zurück (kein LLM-Call nötig)
+
+### 9.2 `InfinityCrossEncoderRerankerTest`
+
+Bestehende `RerankerServiceTest` wird umbenannt und an die neue Constructor-Signatur angepasst (Properties-Pfad ändert sich von `reranker()` auf `reranker().infinity()`). Logik der Tests bleibt identisch.
+
+### 9.3 `NoOpRerankerTest`
+
+Trivial: `rerank()` gibt die ersten `topK` zurück, `candidateCount()` gibt den konfigurierten Wert.
+
+---
+
+## 10. Akzeptanzkriterien
+
+- [ ] `Reranker`-Interface existiert mit `rerank()` und `candidateCount()`
+- [ ] `LlmListwiseReranker` implementiert das Interface, ruft Ollama `/api/generate` auf, parst JSON robust mit allen 11 Test-Szenarien
+- [ ] `InfinityCrossEncoderReranker` ist die umbenannte alte Implementierung, jetzt Interface-konform
+- [ ] `NoOpReranker` ist die explizite "kein Rerank"-Variante
+- [ ] Genau **eine** Reranker-Bean wird beim Start instanziiert (über `@ConditionalOnProperty`)
+- [ ] Default beim Start ohne Config: `LlmListwiseReranker` aktiv
+- [ ] App startet mit `QUERY_RERANKER_TYPE=infinity` (vorausgesetzt Container läuft) — nutzt Infinity
+- [ ] App startet mit `QUERY_RERANKER_TYPE=none` — nutzt NoOp
+- [ ] App startet mit `QUERY_RERANKER_TYPE=llm` (oder ohne Variable) — nutzt LLM
+- [ ] `QueryService` injiziert nur `Reranker`, nicht die konkrete Klasse
+- [ ] LLM-Reranker fällt bei jedem Fehler-Fall (HTTP, Timeout, Parse-Fehler) auf Vektor-Reihenfolge zurück, ohne die Query zu brechen
+- [ ] `application.yml` enthält die neue Config-Struktur mit allen ENV-Variablen
+- [ ] `docker-compose.yml` Reranker-Block ist auskommentiert mit Hinweis
+- [ ] Alle bestehenden Tests grün, plus neue LlmListwiseRerankerTest
+- [ ] `CLAUDE.md` aktualisiert mit den drei Reranker-Modi und Default-Hinweis
+- [ ] Spec 16 markiert als "superseded by Spec 18"
+- [ ] Roadmap (Spec 17) erwähnt den Pivot
+
+---
+
+## 11. Migrations-Hinweis
+
+**Breaking Change** für bestehende Deployments die `QUERY_RERANKER_ENABLED=false` setzen:
+
+- Alt: `QUERY_RERANKER_ENABLED=false`
+- Neu: `QUERY_RERANKER_TYPE=none`
+
+Ohne Anpassung bleibt das Verhalten identisch (wegen `matchIfMissing=true` ist `llm` der Default), aber die alte ENV-Variable wird ignoriert. Im Migrations-Commit wird das in der README/CLAUDE.md vermerkt.
+
+Für die meisten Deployments wird die Umstellung **transparent**: Default-Verhalten ist jetzt LLM-Rerank statt Infinity, was eine Verbesserung gegenüber dem aktuellen `none`-State (Reranker mangels Container deaktiviert) darstellt.
+
+---
+
+## 12. Performance-Erwartung
+
+Mit `qwen3:0.6b` als Reranker-Modell auf moderater Hardware:
+
+- 15 Kandidaten × ~400 Zeichen = ~6000 Zeichen Prompt-Eingabe
+- Output: ~30 Zeichen JSON-Array
+- Erwartete Latenz: **800–2000 ms** pro Rerank-Call
+- Gesamte Query-Latenz (Embed + Search + Rerank + LLM-Antwort): ~3–6 Sekunden (vs. ~2–4 Sek. ohne Rerank)
+
+Wer mehr Präzision und längere Wartezeit toleriert kann auf `gemma3:4b` oder `qwen3:1.7b` umstellen — nur eine ENV-Variable.
+
+Wer maximale Performance braucht und einen GPU-Reranker verfügbar hat, schaltet auf `type=infinity`.
+
+---
+
+## 13. Nicht im Scope
+
+- Caching von Rerank-Ergebnissen (selbe Query → selbes Ranking)
+- Streaming-Rerank während die Antwort generiert wird
+- A/B-Vergleich der drei Reranker im laufenden Betrieb
+- Automatische Modell-Auswahl je nach Query-Typ
+- Erweiterung von `retrieval-quality-check.py` um den Rerank-Pfad zu messen (separates Issue)

--- a/src/main/java/at/openaustria/confluencerag/config/QueryProperties.java
+++ b/src/main/java/at/openaustria/confluencerag/config/QueryProperties.java
@@ -9,7 +9,20 @@ public record QueryProperties(
     RerankerProperties reranker
 ) {
     public record RerankerProperties(
-        boolean enabled,
+        String type,                              // llm | infinity | none
+        LlmRerankerProperties llm,
+        InfinityRerankerProperties infinity
+    ) {}
+
+    public record LlmRerankerProperties(
+        String baseUrl,
+        String model,
+        int candidateCount,
+        int timeoutSeconds,
+        int maxChunkChars
+    ) {}
+
+    public record InfinityRerankerProperties(
         String baseUrl,
         String model,
         int candidateCount,

--- a/src/main/java/at/openaustria/confluencerag/query/InfinityCrossEncoderReranker.java
+++ b/src/main/java/at/openaustria/confluencerag/query/InfinityCrossEncoderReranker.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.document.Document;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
@@ -16,20 +17,23 @@ import java.util.List;
  * Cross-encoder reranker that calls an external infinity container
  * (BAAI/bge-reranker-v2-m3) to re-score vector search candidates.
  *
- * Falls back to the original candidate order on any HTTP error or when
- * disabled via configuration, so failures never break the query path.
+ * Activated via {@code query.reranker.type=infinity}. Requires the
+ * infinity container (~4.5 GB) to be running and reachable. Falls back
+ * to the original candidate order on any HTTP error so failures never
+ * break the query path.
  */
 @Service
-public class RerankerService {
+@ConditionalOnProperty(prefix = "query.reranker", name = "type", havingValue = "infinity")
+public class InfinityCrossEncoderReranker implements Reranker {
 
-    private static final Logger log = LoggerFactory.getLogger(RerankerService.class);
+    private static final Logger log = LoggerFactory.getLogger(InfinityCrossEncoderReranker.class);
 
-    private final QueryProperties.RerankerProperties config;
+    private final QueryProperties.InfinityRerankerProperties config;
     private final RestClient restClient;
 
     @Autowired
-    public RerankerService(QueryProperties queryProperties) {
-        this.config = queryProperties.reranker();
+    public InfinityCrossEncoderReranker(QueryProperties queryProperties) {
+        this.config = queryProperties.reranker().infinity();
 
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
         requestFactory.setConnectTimeout(Duration.ofSeconds(5));
@@ -40,27 +44,23 @@ public class RerankerService {
                 .requestFactory(requestFactory)
                 .build();
 
-        log.info("RerankerService konfiguriert: enabled={}, baseUrl={}, model={}, candidateCount={}",
-                config.enabled(), config.baseUrl(), config.model(), config.candidateCount());
+        log.info("InfinityCrossEncoderReranker konfiguriert: baseUrl={}, model={}, candidateCount={}",
+                config.baseUrl(), config.model(), config.candidateCount());
     }
 
     /**
      * Package-private constructor for tests — allows injecting a RestClient
      * pointed at a test HTTP server.
      */
-    RerankerService(QueryProperties queryProperties, RestClient restClient) {
-        this.config = queryProperties.reranker();
+    InfinityCrossEncoderReranker(QueryProperties queryProperties, RestClient restClient) {
+        this.config = queryProperties.reranker().infinity();
         this.restClient = restClient;
     }
 
-    /**
-     * Re-ranks the candidates by querying the external reranker service.
-     * Returns up to {@code topK} documents in the new order. Falls back
-     * to the first {@code topK} original candidates on any error.
-     */
+    @Override
     public List<Document> rerank(String query, List<Document> candidates, int topK) {
-        if (!config.enabled() || candidates.isEmpty()) {
-            return candidates.stream().limit(topK).toList();
+        if (candidates.isEmpty()) {
+            return List.of();
         }
 
         try {
@@ -92,6 +92,7 @@ public class RerankerService {
         }
     }
 
+    @Override
     public int candidateCount() {
         return config.candidateCount();
     }

--- a/src/main/java/at/openaustria/confluencerag/query/LlmListwiseReranker.java
+++ b/src/main/java/at/openaustria/confluencerag/query/LlmListwiseReranker.java
@@ -1,0 +1,209 @@
+package at.openaustria.confluencerag.query;
+
+import at.openaustria.confluencerag.config.QueryProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.document.Document;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Listwise reranker that uses a small Ollama LLM to score the top-N
+ * vector-search candidates in a single chat call.
+ *
+ * Approach: build a numbered list of all candidates with title + truncated
+ * content, ask the LLM to return the indices of the top-K relevant ones
+ * as a JSON array, parse the array robustly and reorder the documents.
+ *
+ * Falls back to the original vector-order on any error (HTTP failure,
+ * timeout, JSON parse problem) so the query path stays safe.
+ */
+@Service
+@ConditionalOnProperty(prefix = "query.reranker", name = "type",
+        havingValue = "llm", matchIfMissing = true)
+public class LlmListwiseReranker implements Reranker {
+
+    private static final Logger log = LoggerFactory.getLogger(LlmListwiseReranker.class);
+
+    /** Match the first JSON array literal in any string, even with extra text around it. */
+    private static final Pattern JSON_ARRAY_PATTERN = Pattern.compile("\\[\\s*\\d+(?:\\s*,\\s*\\d+)*\\s*]");
+
+    private final QueryProperties.LlmRerankerProperties config;
+    private final RestClient restClient;
+
+    @Autowired
+    public LlmListwiseReranker(QueryProperties queryProperties) {
+        this.config = queryProperties.reranker().llm();
+
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(Duration.ofSeconds(5));
+        requestFactory.setReadTimeout(Duration.ofSeconds(config.timeoutSeconds()));
+
+        this.restClient = RestClient.builder()
+                .baseUrl(config.baseUrl())
+                .requestFactory(requestFactory)
+                .build();
+
+        log.info("LlmListwiseReranker konfiguriert: baseUrl={}, model={}, candidateCount={}, maxChunkChars={}",
+                config.baseUrl(), config.model(), config.candidateCount(), config.maxChunkChars());
+    }
+
+    /**
+     * Package-private constructor for tests — allows injecting a RestClient
+     * pointed at a test HTTP server.
+     */
+    LlmListwiseReranker(QueryProperties queryProperties, RestClient restClient) {
+        this.config = queryProperties.reranker().llm();
+        this.restClient = restClient;
+    }
+
+    @Override
+    public List<Document> rerank(String query, List<Document> candidates, int topK) {
+        if (candidates.isEmpty()) {
+            return List.of();
+        }
+        if (candidates.size() <= topK) {
+            return candidates;
+        }
+
+        try {
+            String prompt = buildPrompt(query, candidates, topK);
+            String responseText = callOllama(prompt);
+
+            List<Integer> oneBasedIndices = parseJsonArray(responseText);
+            return mapToDocuments(oneBasedIndices, candidates, topK);
+        } catch (Exception e) {
+            log.warn("LLM-Rerank fehlgeschlagen, fallback auf Vektor-Reihenfolge: {}",
+                    e.getMessage());
+            return candidates.stream().limit(topK).toList();
+        }
+    }
+
+    @Override
+    public int candidateCount() {
+        return config.candidateCount();
+    }
+
+    private String buildPrompt(String query, List<Document> candidates, int topK) {
+        StringBuilder sb = new StringBuilder(2048);
+        sb.append("Du bist ein Such-Assistent. Bewerte die Relevanz folgender Dokument-Auszüge ")
+          .append("für die Frage.\n\n");
+        sb.append("Frage: \"").append(query).append("\"\n\n");
+        sb.append("Dokumente:\n");
+
+        int n = Math.min(candidates.size(), config.candidateCount());
+        for (int i = 0; i < n; i++) {
+            Document doc = candidates.get(i);
+            String title = (String) doc.getMetadata().getOrDefault("pageTitle", "");
+            String text = doc.getText() == null ? "" : doc.getText();
+            String truncated = text.length() > config.maxChunkChars()
+                    ? text.substring(0, config.maxChunkChars()) + "..."
+                    : text;
+            sb.append("[").append(i + 1).append("] Titel: ").append(title).append("\n");
+            sb.append(truncated).append("\n\n");
+        }
+
+        sb.append("Gib die Nummern der ").append(topK)
+          .append(" relevantesten Dokumente in absteigender Relevanz als JSON-Array zurück. ")
+          .append("Beispiel: [3, 7, 1, 12, 5]\n\n")
+          .append("Antworte AUSSCHLIESSLICH mit dem Array. Keine Erklärung, kein Markdown, ")
+          .append("keine Anführungszeichen drumherum. Nur das Array.");
+        return sb.toString();
+    }
+
+    private String callOllama(String prompt) {
+        OllamaRequest req = new OllamaRequest(
+                config.model(),
+                prompt,
+                false,
+                new OllamaOptions(0.0, 0.1, 64));
+
+        OllamaResponse resp = restClient.post()
+                .uri("/api/generate")
+                .body(req)
+                .retrieve()
+                .body(OllamaResponse.class);
+
+        if (resp == null || resp.response() == null) {
+            throw new IllegalStateException("Empty Ollama response");
+        }
+        return resp.response();
+    }
+
+    /**
+     * Extract a list of integers from the LLM response. Handles markdown wraps,
+     * leading/trailing text, and missing brackets by using a regex to find the
+     * first JSON-array-shaped substring.
+     */
+    static List<Integer> parseJsonArray(String text) {
+        if (text == null || text.isBlank()) {
+            return List.of();
+        }
+        Matcher m = JSON_ARRAY_PATTERN.matcher(text);
+        if (!m.find()) {
+            return List.of();
+        }
+        String arrayLiteral = m.group();
+        // Strip brackets, split, parse
+        String inner = arrayLiteral.substring(1, arrayLiteral.length() - 1);
+        List<Integer> result = new ArrayList<>();
+        for (String token : inner.split(",")) {
+            String trimmed = token.trim();
+            if (trimmed.isEmpty()) continue;
+            try {
+                result.add(Integer.parseInt(trimmed));
+            } catch (NumberFormatException ignored) {
+                // skip non-numeric tokens
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Map LLM-returned 1-based indices to documents, validating range and
+     * removing duplicates. Pads with original-order top documents if the
+     * LLM returned fewer than topK valid indices.
+     */
+    private List<Document> mapToDocuments(List<Integer> oneBasedIndices,
+                                          List<Document> candidates,
+                                          int topK) {
+        Set<Integer> usedZeroBased = new LinkedHashSet<>();
+        for (Integer idx : oneBasedIndices) {
+            if (idx == null) continue;
+            int zeroBased = idx - 1;
+            if (zeroBased >= 0 && zeroBased < candidates.size()) {
+                usedZeroBased.add(zeroBased);
+            }
+            if (usedZeroBased.size() >= topK) break;
+        }
+
+        // Pad with original-order top documents not yet used
+        if (usedZeroBased.size() < topK) {
+            for (int i = 0; i < candidates.size() && usedZeroBased.size() < topK; i++) {
+                usedZeroBased.add(i);
+            }
+        }
+
+        List<Document> result = new ArrayList<>(usedZeroBased.size());
+        for (Integer idx : usedZeroBased) {
+            result.add(candidates.get(idx));
+        }
+        return result;
+    }
+
+    record OllamaRequest(String model, String prompt, boolean stream, OllamaOptions options) {}
+    record OllamaOptions(double temperature, double top_p, int num_predict) {}
+    record OllamaResponse(String model, String response) {}
+}

--- a/src/main/java/at/openaustria/confluencerag/query/NoOpReranker.java
+++ b/src/main/java/at/openaustria/confluencerag/query/NoOpReranker.java
@@ -1,0 +1,41 @@
+package at.openaustria.confluencerag.query;
+
+import at.openaustria.confluencerag.config.QueryProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.document.Document;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Pass-through reranker — keeps the original vector-search order.
+ *
+ * Activated explicitly via {@code query.reranker.type=none}. Useful for
+ * disabling reranking without compiling out the rest of the pipeline.
+ */
+@Service
+@ConditionalOnProperty(prefix = "query.reranker", name = "type", havingValue = "none")
+public class NoOpReranker implements Reranker {
+
+    private static final Logger log = LoggerFactory.getLogger(NoOpReranker.class);
+
+    private final int candidateCount;
+
+    public NoOpReranker(QueryProperties queryProperties) {
+        // No reranking → fetching more than topK from Qdrant is pointless
+        this.candidateCount = queryProperties.topK();
+        log.info("NoOpReranker aktiv: kein Reranking, candidateCount={}", candidateCount);
+    }
+
+    @Override
+    public List<Document> rerank(String query, List<Document> candidates, int topK) {
+        return candidates.stream().limit(topK).toList();
+    }
+
+    @Override
+    public int candidateCount() {
+        return candidateCount;
+    }
+}

--- a/src/main/java/at/openaustria/confluencerag/query/QueryService.java
+++ b/src/main/java/at/openaustria/confluencerag/query/QueryService.java
@@ -52,14 +52,14 @@ public class QueryService {
     private final VectorStore vectorStore;
     private final ChatClient chatClient;
     private final QueryProperties queryProperties;
-    private final RerankerService rerankerService;
+    private final Reranker reranker;
 
     public QueryService(VectorStore vectorStore, ChatClient.Builder chatClientBuilder,
-                        QueryProperties queryProperties, RerankerService rerankerService) {
+                        QueryProperties queryProperties, Reranker reranker) {
         this.vectorStore = vectorStore;
         this.chatClient = chatClientBuilder.build();
         this.queryProperties = queryProperties;
-        this.rerankerService = rerankerService;
+        this.reranker = reranker;
     }
 
     public QueryResponse query(QueryRequest request) {
@@ -67,7 +67,6 @@ public class QueryService {
         log.info("Query: \"{}\" (Filter: {})", request.question(), request.spaceFilter());
 
         List<Document> relevantDocs = searchRelevantDocs(request);
-        log.info("Similarity Search: {} Ergebnisse", relevantDocs.size());
 
         List<Source> sources = extractSources(relevantDocs);
         String context = buildContext(relevantDocs);
@@ -101,10 +100,9 @@ public class QueryService {
     }
 
     private List<Document> searchRelevantDocs(QueryRequest request) {
-        // Fetch a candidate set for cross-encoder reranking, then return top-K.
-        // The reranker provides much higher precision than the previous keyword
-        // heuristic, so a smaller candidate set is sufficient.
-        int fetchK = Math.max(queryProperties.topK(), rerankerService.candidateCount());
+        // Fetch a candidate set sized to the active reranker's needs,
+        // then let the reranker reorder them and return the top-K.
+        int fetchK = Math.max(queryProperties.topK(), reranker.candidateCount());
         SearchRequest.Builder searchBuilder = SearchRequest.builder()
                 .query(request.question())
                 .topK(fetchK)
@@ -122,7 +120,11 @@ public class QueryService {
         }
 
         List<Document> candidates = vectorStore.similaritySearch(searchBuilder.build());
-        return rerankerService.rerank(request.question(), candidates, queryProperties.topK());
+        log.info("Vektor-Suche: {} Kandidaten (fetchK={}, threshold={})",
+                candidates.size(), fetchK, queryProperties.similarityThreshold());
+        List<Document> reranked = reranker.rerank(request.question(), candidates, queryProperties.topK());
+        log.info("Nach Rerank: {} Dokumente", reranked.size());
+        return reranked;
     }
 
     private String buildContext(List<Document> relevantDocs) {

--- a/src/main/java/at/openaustria/confluencerag/query/Reranker.java
+++ b/src/main/java/at/openaustria/confluencerag/query/Reranker.java
@@ -1,0 +1,31 @@
+package at.openaustria.confluencerag.query;
+
+import org.springframework.ai.document.Document;
+
+import java.util.List;
+
+/**
+ * Reordering strategy applied to vector-search candidates before they
+ * are passed to the LLM as context. Implementations choose how to
+ * compute relevance scores (LLM listwise, cross-encoder, no-op, ...).
+ *
+ * Spring activates exactly one bean implementing this interface based
+ * on {@code query.reranker.type} via {@code @ConditionalOnProperty}.
+ */
+public interface Reranker {
+
+    /**
+     * Re-rank the given candidates and return the top {@code topK}
+     * documents in new order. Implementations must fall back to the
+     * original order on any error to keep the query path safe.
+     */
+    List<Document> rerank(String query, List<Document> candidates, int topK);
+
+    /**
+     * Number of candidates the QueryService should fetch from Qdrant
+     * before passing them to this reranker. Implementations have
+     * different sweet spots: LLMs are limited by context window,
+     * cross-encoders can handle more, no-op needs only top-K.
+     */
+    int candidateCount();
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,11 +31,18 @@ query:
   top-k: ${QUERY_TOP_K:5}
   similarity-threshold: ${QUERY_SIMILARITY_THRESHOLD:0.45}
   reranker:
-    enabled: ${QUERY_RERANKER_ENABLED:true}
-    base-url: ${QUERY_RERANKER_URL:http://localhost:7997}
-    model: ${QUERY_RERANKER_MODEL:BAAI/bge-reranker-v2-m3}
-    candidate-count: ${QUERY_RERANKER_CANDIDATES:30}
-    timeout-seconds: ${QUERY_RERANKER_TIMEOUT:10}
+    type: ${QUERY_RERANKER_TYPE:llm}              # llm | infinity | none
+    llm:
+      base-url: ${QUERY_RERANKER_LLM_URL:http://localhost:11434}
+      model: ${QUERY_RERANKER_LLM_MODEL:qwen3:0.6b}
+      candidate-count: ${QUERY_RERANKER_LLM_CANDIDATES:15}
+      timeout-seconds: ${QUERY_RERANKER_LLM_TIMEOUT:60}
+      max-chunk-chars: ${QUERY_RERANKER_LLM_MAX_CHUNK:500}
+    infinity:
+      base-url: ${QUERY_RERANKER_INFINITY_URL:http://localhost:7997}
+      model: ${QUERY_RERANKER_INFINITY_MODEL:BAAI/bge-reranker-v2-m3}
+      candidate-count: ${QUERY_RERANKER_INFINITY_CANDIDATES:30}
+      timeout-seconds: ${QUERY_RERANKER_INFINITY_TIMEOUT:10}
 
 confluence:
   base-url: ${CONFLUENCE_BASE_URL:http://localhost:8090}

--- a/src/test/java/at/openaustria/confluencerag/query/InfinityCrossEncoderRerankerTest.java
+++ b/src/test/java/at/openaustria/confluencerag/query/InfinityCrossEncoderRerankerTest.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class RerankerServiceTest {
+class InfinityCrossEncoderRerankerTest {
 
     private HttpServer server;
     private String baseUrl;
@@ -35,15 +35,19 @@ class RerankerServiceTest {
         server.stop(0);
     }
 
-    private QueryProperties props(boolean enabled, int candidateCount) {
+    private QueryProperties props(int candidateCount) {
         return new QueryProperties(5, 0.45,
                 new QueryProperties.RerankerProperties(
-                        enabled, baseUrl, "BAAI/bge-reranker-v2-m3", candidateCount, 5));
+                        "infinity",
+                        new QueryProperties.LlmRerankerProperties(
+                                "http://localhost:11434", "qwen3:0.6b", 15, 60, 500),
+                        new QueryProperties.InfinityRerankerProperties(
+                                baseUrl, "BAAI/bge-reranker-v2-m3", candidateCount, 5)));
     }
 
-    private RerankerService serviceFor(QueryProperties properties) {
+    private InfinityCrossEncoderReranker serviceFor(QueryProperties properties) {
         RestClient client = RestClient.builder().baseUrl(baseUrl).build();
-        return new RerankerService(properties, client);
+        return new InfinityCrossEncoderReranker(properties, client);
     }
 
     private Document doc(String title, String text) {
@@ -70,7 +74,7 @@ class RerankerServiceTest {
             }
         });
 
-        RerankerService service = serviceFor(props(true, 30));
+        InfinityCrossEncoderReranker service = serviceFor(props(30));
         List<Document> candidates = List.of(
                 doc("Page A", "first text"),
                 doc("Page B", "second text"),
@@ -101,7 +105,7 @@ class RerankerServiceTest {
             }
         });
 
-        RerankerService service = serviceFor(props(true, 30));
+        InfinityCrossEncoderReranker service = serviceFor(props(30));
         List<Document> candidates = List.of(
                 doc("A", "x"), doc("B", "y"), doc("C", "z"));
 
@@ -121,7 +125,7 @@ class RerankerServiceTest {
             exchange.close();
         });
 
-        RerankerService service = serviceFor(props(true, 30));
+        InfinityCrossEncoderReranker service = serviceFor(props(30));
         List<Document> candidates = List.of(
                 doc("A", "x"), doc("B", "y"), doc("C", "z"));
 
@@ -135,27 +139,8 @@ class RerankerServiceTest {
     }
 
     @Test
-    void rerank_skipsServerCall_whenDisabled() {
-        AtomicInteger calls = new AtomicInteger();
-        server.createContext("/rerank", exchange -> {
-            calls.incrementAndGet();
-            exchange.sendResponseHeaders(200, -1);
-            exchange.close();
-        });
-
-        RerankerService service = serviceFor(props(false, 30));
-        List<Document> candidates = List.of(doc("A", "x"), doc("B", "y"));
-
-        List<Document> result = service.rerank("q", candidates, 5);
-
-        assertEquals(0, calls.get());
-        assertEquals(2, result.size());
-        assertEquals("A", result.get(0).getMetadata().get("pageTitle"));
-    }
-
-    @Test
     void rerank_returnsEmptyList_forEmptyInput() {
-        RerankerService service = serviceFor(props(true, 30));
+        InfinityCrossEncoderReranker service = serviceFor(props(30));
         List<Document> result = service.rerank("q", List.of(), 5);
         assertTrue(result.isEmpty());
     }
@@ -177,7 +162,7 @@ class RerankerServiceTest {
             }
         });
 
-        RerankerService service = serviceFor(props(true, 30));
+        InfinityCrossEncoderReranker service = serviceFor(props(30));
         List<Document> candidates = List.of(doc("A", "x"), doc("B", "y"));
 
         List<Document> result = service.rerank("q", candidates, 5);
@@ -188,7 +173,7 @@ class RerankerServiceTest {
 
     @Test
     void candidateCount_returnsConfiguredValue() {
-        RerankerService service = serviceFor(props(true, 42));
+        InfinityCrossEncoderReranker service = serviceFor(props(42));
         assertEquals(42, service.candidateCount());
     }
 }

--- a/src/test/java/at/openaustria/confluencerag/query/LlmListwiseRerankerTest.java
+++ b/src/test/java/at/openaustria/confluencerag/query/LlmListwiseRerankerTest.java
@@ -1,0 +1,294 @@
+package at.openaustria.confluencerag.query;
+
+import at.openaustria.confluencerag.config.QueryProperties;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+import org.springframework.web.client.RestClient;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LlmListwiseRerankerTest {
+
+    private HttpServer server;
+    private String baseUrl;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.start();
+        baseUrl = "http://localhost:" + server.getAddress().getPort();
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    private QueryProperties props(int candidateCount) {
+        return props(candidateCount, 60);
+    }
+
+    private QueryProperties props(int candidateCount, int timeoutSeconds) {
+        return new QueryProperties(5, 0.45,
+                new QueryProperties.RerankerProperties(
+                        "llm",
+                        new QueryProperties.LlmRerankerProperties(
+                                baseUrl, "qwen3:0.6b", candidateCount, timeoutSeconds, 500),
+                        new QueryProperties.InfinityRerankerProperties(
+                                "http://localhost:7997", "BAAI/bge-reranker-v2-m3", 30, 10)));
+    }
+
+    private LlmListwiseReranker rerankerFor(QueryProperties properties) {
+        RestClient client = RestClient.builder().baseUrl(baseUrl).build();
+        return new LlmListwiseReranker(properties, client);
+    }
+
+    private Document doc(String title, String text) {
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("pageTitle", title);
+        return new Document(text, meta);
+    }
+
+    private void respondJson(HttpExchange exchange, String responseField) throws IOException {
+        String json = "{\"model\":\"qwen3:0.6b\",\"response\":" + jsonString(responseField) + "}";
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, json.getBytes().length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(json.getBytes());
+        }
+    }
+
+    private String jsonString(String s) {
+        return "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n") + "\"";
+    }
+
+    private List<Document> sixCandidates() {
+        return List.of(
+                doc("Doc1", "alpha"),
+                doc("Doc2", "beta"),
+                doc("Doc3", "gamma"),
+                doc("Doc4", "delta"),
+                doc("Doc5", "epsilon"),
+                doc("Doc6", "zeta"));
+    }
+
+    // -------- 1. Happy path --------
+
+    @Test
+    void rerank_happyPath_reordersByLlmRanking() {
+        server.createContext("/api/generate", exchange -> respondJson(exchange, "[3, 1, 5]"));
+
+        LlmListwiseReranker reranker = rerankerFor(props(15));
+        List<Document> result = reranker.rerank("q", sixCandidates(), 3);
+
+        assertEquals(3, result.size());
+        assertEquals("Doc3", result.get(0).getMetadata().get("pageTitle"));
+        assertEquals("Doc1", result.get(1).getMetadata().get("pageTitle"));
+        assertEquals("Doc5", result.get(2).getMetadata().get("pageTitle"));
+    }
+
+    // -------- 2. Markdown wrap --------
+
+    @Test
+    void rerank_extractsArrayFromMarkdownCodeBlock() {
+        server.createContext("/api/generate", exchange ->
+                respondJson(exchange, "```json\n[2, 4]\n```"));
+
+        LlmListwiseReranker reranker = rerankerFor(props(15));
+        List<Document> result = reranker.rerank("q", sixCandidates(), 2);
+
+        assertEquals(2, result.size());
+        assertEquals("Doc2", result.get(0).getMetadata().get("pageTitle"));
+        assertEquals("Doc4", result.get(1).getMetadata().get("pageTitle"));
+    }
+
+    // -------- 3. Explanation text before --------
+
+    @Test
+    void rerank_extractsArrayFromTextWithExplanation() {
+        server.createContext("/api/generate", exchange ->
+                respondJson(exchange, "Hier sind die relevantesten: [3, 6, 1] — viel Erfolg!"));
+
+        LlmListwiseReranker reranker = rerankerFor(props(15));
+        List<Document> result = reranker.rerank("q", sixCandidates(), 3);
+
+        assertEquals(3, result.size());
+        assertEquals("Doc3", result.get(0).getMetadata().get("pageTitle"));
+        assertEquals("Doc6", result.get(1).getMetadata().get("pageTitle"));
+        assertEquals("Doc1", result.get(2).getMetadata().get("pageTitle"));
+    }
+
+    // -------- 4. Out-of-range index --------
+
+    @Test
+    void rerank_skipsOutOfRangeIndices() {
+        server.createContext("/api/generate", exchange -> respondJson(exchange, "[99, 2, 100, 4]"));
+
+        LlmListwiseReranker reranker = rerankerFor(props(15));
+        List<Document> result = reranker.rerank("q", sixCandidates(), 2);
+
+        assertEquals(2, result.size());
+        assertEquals("Doc2", result.get(0).getMetadata().get("pageTitle"));
+        assertEquals("Doc4", result.get(1).getMetadata().get("pageTitle"));
+    }
+
+    // -------- 5. Duplicates --------
+
+    @Test
+    void rerank_dedupsRepeatedIndices() {
+        server.createContext("/api/generate", exchange -> respondJson(exchange, "[1, 1, 2, 2, 3]"));
+
+        LlmListwiseReranker reranker = rerankerFor(props(15));
+        List<Document> result = reranker.rerank("q", sixCandidates(), 3);
+
+        assertEquals(3, result.size());
+        assertEquals("Doc1", result.get(0).getMetadata().get("pageTitle"));
+        assertEquals("Doc2", result.get(1).getMetadata().get("pageTitle"));
+        assertEquals("Doc3", result.get(2).getMetadata().get("pageTitle"));
+    }
+
+    // -------- 6. Too few indices → padded --------
+
+    @Test
+    void rerank_padsWithOriginalOrderWhenTooFewIndices() {
+        // LLM only returns one valid index, topK=4 → must pad with original-order candidates
+        server.createContext("/api/generate", exchange -> respondJson(exchange, "[5]"));
+
+        LlmListwiseReranker reranker = rerankerFor(props(15));
+        List<Document> result = reranker.rerank("q", sixCandidates(), 4);
+
+        assertEquals(4, result.size());
+        // First should be the LLM-picked Doc5
+        assertEquals("Doc5", result.get(0).getMetadata().get("pageTitle"));
+        // Then padded with original order, skipping Doc5 which is already used
+        assertEquals("Doc1", result.get(1).getMetadata().get("pageTitle"));
+        assertEquals("Doc2", result.get(2).getMetadata().get("pageTitle"));
+        assertEquals("Doc3", result.get(3).getMetadata().get("pageTitle"));
+    }
+
+    // -------- 7. HTTP 500 error --------
+
+    @Test
+    void rerank_fallsBackOnHttpError() {
+        AtomicInteger calls = new AtomicInteger();
+        server.createContext("/api/generate", exchange -> {
+            calls.incrementAndGet();
+            exchange.sendResponseHeaders(500, -1);
+            exchange.close();
+        });
+
+        LlmListwiseReranker reranker = rerankerFor(props(15));
+        List<Document> result = reranker.rerank("q", sixCandidates(), 3);
+
+        assertEquals(1, calls.get());
+        assertEquals(3, result.size());
+        assertEquals("Doc1", result.get(0).getMetadata().get("pageTitle"));
+        assertEquals("Doc2", result.get(1).getMetadata().get("pageTitle"));
+        assertEquals("Doc3", result.get(2).getMetadata().get("pageTitle"));
+    }
+
+    // -------- 8. Timeout --------
+
+    @Test
+    void rerank_fallsBackOnTimeout() {
+        server.createContext("/api/generate", exchange -> {
+            try {
+                Thread.sleep(2500); // longer than timeout
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+            respondJson(exchange, "[1, 2, 3]");
+        });
+
+        LlmListwiseReranker reranker = rerankerFor(props(15, 1)); // 1s timeout
+        List<Document> result = reranker.rerank("q", sixCandidates(), 3);
+
+        // Should fall back to original order
+        assertEquals(3, result.size());
+        assertEquals("Doc1", result.get(0).getMetadata().get("pageTitle"));
+    }
+
+    // -------- 9. Garbage response --------
+
+    @Test
+    void rerank_fallsBackOnGarbageResponse() {
+        server.createContext("/api/generate", exchange ->
+                respondJson(exchange, "lorem ipsum dolor sit amet"));
+
+        LlmListwiseReranker reranker = rerankerFor(props(15));
+        List<Document> result = reranker.rerank("q", sixCandidates(), 3);
+
+        // No valid array → mapToDocuments pads with original order
+        assertEquals(3, result.size());
+        assertEquals("Doc1", result.get(0).getMetadata().get("pageTitle"));
+        assertEquals("Doc2", result.get(1).getMetadata().get("pageTitle"));
+        assertEquals("Doc3", result.get(2).getMetadata().get("pageTitle"));
+    }
+
+    // -------- 10. Empty input --------
+
+    @Test
+    void rerank_returnsEmptyForEmptyInput() {
+        LlmListwiseReranker reranker = rerankerFor(props(15));
+        List<Document> result = reranker.rerank("q", List.of(), 5);
+        assertTrue(result.isEmpty());
+    }
+
+    // -------- 11. Fewer candidates than topK → no LLM call --------
+
+    @Test
+    void rerank_skipsLlmCallWhenCandidatesUnderTopK() {
+        AtomicInteger calls = new AtomicInteger();
+        server.createContext("/api/generate", exchange -> {
+            calls.incrementAndGet();
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+
+        LlmListwiseReranker reranker = rerankerFor(props(15));
+        List<Document> candidates = List.of(doc("A", "x"), doc("B", "y"));
+        List<Document> result = reranker.rerank("q", candidates, 5);
+
+        assertEquals(0, calls.get());
+        assertEquals(2, result.size());
+    }
+
+    // -------- candidateCount accessor --------
+
+    @Test
+    void candidateCount_returnsConfiguredValue() {
+        LlmListwiseReranker reranker = rerankerFor(props(42));
+        assertEquals(42, reranker.candidateCount());
+    }
+
+    // -------- Static parser unit tests --------
+
+    @Test
+    void parseJsonArray_handlesPlainArray() {
+        assertEquals(List.of(3, 1, 5), LlmListwiseReranker.parseJsonArray("[3, 1, 5]"));
+    }
+
+    @Test
+    void parseJsonArray_handlesArrayInText() {
+        assertEquals(List.of(2, 4), LlmListwiseReranker.parseJsonArray("answer: [2, 4] done"));
+    }
+
+    @Test
+    void parseJsonArray_returnsEmptyForGarbage() {
+        assertTrue(LlmListwiseReranker.parseJsonArray("nothing here").isEmpty());
+        assertTrue(LlmListwiseReranker.parseJsonArray("").isEmpty());
+        assertTrue(LlmListwiseReranker.parseJsonArray(null).isEmpty());
+    }
+}

--- a/src/test/java/at/openaustria/confluencerag/query/NoOpRerankerTest.java
+++ b/src/test/java/at/openaustria/confluencerag/query/NoOpRerankerTest.java
@@ -1,0 +1,56 @@
+package at.openaustria.confluencerag.query;
+
+import at.openaustria.confluencerag.config.QueryProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NoOpRerankerTest {
+
+    private QueryProperties props(int topK) {
+        return new QueryProperties(topK, 0.45,
+                new QueryProperties.RerankerProperties(
+                        "none",
+                        new QueryProperties.LlmRerankerProperties(
+                                "http://localhost:11434", "qwen3:0.6b", 15, 60, 500),
+                        new QueryProperties.InfinityRerankerProperties(
+                                "http://localhost:7997", "BAAI/bge-reranker-v2-m3", 30, 10)));
+    }
+
+    private Document doc(String title) {
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("pageTitle", title);
+        return new Document(title + " text", meta);
+    }
+
+    @Test
+    void rerank_returnsFirstTopKInOriginalOrder() {
+        NoOpReranker reranker = new NoOpReranker(props(5));
+        List<Document> candidates = List.of(
+                doc("A"), doc("B"), doc("C"), doc("D"), doc("E"), doc("F"));
+
+        List<Document> result = reranker.rerank("q", candidates, 3);
+
+        assertEquals(3, result.size());
+        assertEquals("A", result.get(0).getMetadata().get("pageTitle"));
+        assertEquals("B", result.get(1).getMetadata().get("pageTitle"));
+        assertEquals("C", result.get(2).getMetadata().get("pageTitle"));
+    }
+
+    @Test
+    void rerank_returnsEmptyForEmptyInput() {
+        NoOpReranker reranker = new NoOpReranker(props(5));
+        assertTrue(reranker.rerank("q", List.of(), 5).isEmpty());
+    }
+
+    @Test
+    void candidateCount_equalsTopK() {
+        NoOpReranker reranker = new NoOpReranker(props(7));
+        assertEquals(7, reranker.candidateCount());
+    }
+}


### PR DESCRIPTION
## Summary
- Pivot from external infinity container to LLM-based listwise reranking via Ollama
- Both implementations preserved via new `Reranker` interface and `@ConditionalOnProperty` bean selection
- New default: `LlmListwiseReranker` (`query.reranker.type=llm`) — needs only Ollama
- Existing infinity code kept as `InfinityCrossEncoderReranker` (`type=infinity`)
- Explicit `NoOpReranker` (`type=none`) replaces old `enabled=false` flag

Closes #39, supersedes spec 16

## Why
On production target systems Docker Hub is blocked (only a private registry is reachable) and the `michaelf34/infinity:latest` image is ~4.5 GB. Requirement was "reranker under our own control". Ollama already runs on all target systems.

## Architecture
| Type | Bean | When |
|------|------|------|
| `llm` (default) | `LlmListwiseReranker` | Always; Ollama-based listwise via `/api/generate` |
| `infinity` | `InfinityCrossEncoderReranker` | Set `QUERY_RERANKER_TYPE=infinity` |
| `none` | `NoOpReranker` | Set `QUERY_RERANKER_TYPE=none` |

`QueryService` depends on the `Reranker` interface — no knowledge of the active impl.

## LLM Reranker Details
- Single LLM call with all candidates as numbered list
- Robust JSON-array parser: handles markdown wraps, leading text, out-of-range indices, duplicates
- Pads with original-order top documents if LLM returns too few indices
- Falls back to vector order on any error (HTTP, timeout, parse failure)
- Default model: `qwen3:0.6b` (~5s for 15 candidates on CPU)

## Test Plan
- [x] All 67 unit tests green (15 LlmListwise, 3 NoOp, 6 Infinity refactored, 43 existing)
- [x] Live: default start → `LlmListwiseReranker` active in logs
- [x] Live: query with 15 candidates → reranker reduces to 5 in ~5s
- [x] Live: `QUERY_RERANKER_TYPE=none` → `NoOpReranker` active, fetchK=5
- [x] Live: query against PlantUML / Specs returns correct sources
- [ ] Live: `type=infinity` (untested — container nicht verfügbar, durch Unit-Tests abgedeckt)

## Migration
- `QUERY_RERANKER_ENABLED=false` is no longer recognized → use `QUERY_RERANKER_TYPE=none`
- Default behavior changed from "Infinity (config-default)" to "LLM-Listwise"

🤖 Generated with [Claude Code](https://claude.com/claude-code)