### PR TITLE
chore: Extend retrieval-quality-check with rerank compare; fix num_predict for thinking models

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,34 +5,50 @@ Utility-Skripte für Entwicklung, Testing und Diagnose. Nicht Teil der produktiv
 | Script | Zweck |
 |--------|-------|
 | `generate-test-pages.py` | Erzeugt synthetische Test-Seiten im lokalen Confluence-Container |
-| `retrieval-quality-check.py` | Führt Test-Queries gegen die Qdrant-Collection aus und prüft Scores/Top-Matches |
+| `retrieval-quality-check.py` | Führt Test-Queries gegen die Qdrant-Collection aus, vergleicht Vektor-Suche mit/ohne LLM-Listwise-Rerank |
 
 ---
 
 ## `retrieval-quality-check.py`
 
-Diagnose-Script das eine feste Liste von Test-Queries gegen die laufende Qdrant-Collection schickt und die Top-K Treffer mit Similarity-Scores ausgibt. Hilft beim Vergleichen von Embedding-Modellen, Kalibrieren des Similarity-Thresholds und Spot-Checks nach Ingest-Änderungen.
+Diagnose-Script das eine feste Liste von Test-Queries gegen die laufende Qdrant-Collection schickt und die Top-K Treffer mit Similarity-Scores ausgibt. Unterstützt drei Modi:
+
+- **`vector`** — nur die rohe Vektor-Suche (das "vor dem Reranker"-Baseline)
+- **`rerank`** — nur die Top-K nach LLM-Listwise-Rerank (das "nach dem Reranker"-View)
+- **`both`** (Default) — Side-by-Side mit Rang-Änderungs-Pfeilen
+
+Die Rerank-Logik im Script ist eine 1:1-Reproduktion des Java `LlmListwiseReranker` (gleicher Prompt, gleicher JSON-Parser). Wenn der Java-Code geändert wird, muss das Script mit-aktualisiert werden — die Synchronisation ist manuell aber bewusst, weil das Script ein eigenständiges Diagnose-Tool ist und die App nicht laufen muss.
 
 ### Voraussetzungen
 
 - Ollama läuft auf `OLLAMA_URL` (default `http://localhost:11434`) und hat das Embedding-Modell verfügbar
 - Qdrant läuft auf `QDRANT_URL` (default `http://localhost:6333`) und hat die Collection ingestet
+- Für `MODE=rerank` und `MODE=both`: zusätzlich das Rerank-LLM (default `qwen3:0.6b`)
 - Python 3 (nur stdlib, keine extra Dependencies)
 
 ### Benutzung
 
 ```bash
-# Defaults: bge-m3 gegen localhost
+# Defaults: bge-m3 + qwen3:0.6b Rerank, Side-by-Side
 python3 scripts/retrieval-quality-check.py
 
-# Anderes Modell zum Vergleich (z.B. alter Stand mit nomic-embed-text)
+# Nur Vektor-Baseline (kein Rerank-Call → spart Latenz)
+MODE=vector python3 scripts/retrieval-quality-check.py
+
+# Nur Reranker-Output
+MODE=rerank python3 scripts/retrieval-quality-check.py
+
+# Mit anderem Rerank-Modell vergleichen
+RERANK_MODEL=gemma3:4b python3 scripts/retrieval-quality-check.py
+
+# Mit anderem Embedding-Modell (alter Stand: nomic-embed-text)
 EMBED_MODEL=nomic-embed-text python3 scripts/retrieval-quality-check.py
 
 # Anderer Qdrant-Host / andere Collection
 QDRANT_URL=http://qdrant.prod:6333 COLLECTION=my-collection \
   python3 scripts/retrieval-quality-check.py
 
-# Ad-hoc Einzel-Query von der Kommandozeile
+# Ad-hoc Einzel-Query
 python3 scripts/retrieval-quality-check.py "Wie funktioniert X?"
 ```
 
@@ -40,11 +56,16 @@ python3 scripts/retrieval-quality-check.py "Wie funktioniert X?"
 
 | Variable | Default | Bedeutung |
 |----------|---------|-----------|
-| `OLLAMA_URL` | `http://localhost:11434` | Ollama-Endpoint für Embeddings |
+| `OLLAMA_URL` | `http://localhost:11434` | Ollama-Endpoint für Embeddings + Rerank |
 | `QDRANT_URL` | `http://localhost:6333` | Qdrant-REST-Endpoint |
 | `COLLECTION` | `confluence-chunks` | Qdrant-Collection-Name |
 | `EMBED_MODEL` | `bge-m3` | Ollama-Embedding-Modell |
-| `TOP_K` | `10` | Anzahl der zurückgegebenen Treffer pro Query |
+| `TOP_K` | `5` | Anzahl der zurückgegebenen Treffer pro Query |
+| `MODE` | `both` | `vector` \| `rerank` \| `both` |
+| `RERANK_MODEL` | `qwen3:0.6b` | Ollama-Modell für den Listwise-Rerank |
+| `CANDIDATE_COUNT` | `15` | Anzahl Kandidaten die in den Reranker gehen |
+| `MAX_CHUNK_CHARS` | `500` | Truncation pro Chunk im Rerank-Prompt |
+| `RERANK_TIMEOUT` | `60` | Timeout für den Rerank-LLM-Call (Sekunden) |
 
 ### Test-Queries anpassen
 
@@ -52,22 +73,42 @@ Die Queries sind oben im Script als `QUERIES`-Liste hart kodiert — zu jedem Qu
 
 ### Interpretation der Ausgabe
 
-Pro Query:
-- `top1` / `top10` — höchster und niedrigster Score in den Top-K
+**MODE=vector** und **MODE=rerank** zeigen pro Query:
+- `top1` / `top<K>` — höchster und niedrigster Score in den Top-K
 - `spread` — Differenz (zeigt wie "eng" das Score-Band ist; bei Single-Domain-Corpora oft problematisch eng)
 - Numerierte Treffer-Liste mit Score, Space-Key und Titel
+
+**MODE=both** zeigt zusätzlich die Bewegung jedes Treffers durch den Rerank:
+- `↑ from #N` — der Reranker hat das Dokument nach oben geschoben
+- `↓ from #N` — der Reranker hat es nach unten geschoben
+- `= unchanged` — gleiche Position
+- `★ promoted (was #N)` — war außerhalb der Vector-Top-K und wurde reingepromoted
+
+So ist auf einen Blick zu sehen, ob und wo der Reranker tatsächlich Werte schafft.
 
 **Faustregeln für bge-m3 auf deutschem Content:**
 - Relevanter Treffer: `> 0.50`
 - Off-topic: meist `< 0.45` (deshalb der Default-Threshold)
-- Spread unter `0.05`: Keyword-Heuristik oder Reranker helfen am meisten
+- Spread unter `0.05`: Reranker-Effekt am wahrscheinlichsten
 
 ### Wann verwenden
 
-- Vor/nach Embedding-Modell-Wechsel → Before/After-Vergleich
+- Vor/nach Embedding-Modell-Wechsel → Before/After-Vergleich (`EMBED_MODEL` umsetzen)
+- Vor/nach Reranker-Aktivierung → `MODE=both` zeigt Rang-Änderungen
+- Vergleich verschiedener Rerank-Modelle (`RERANK_MODEL=qwen3:0.6b` vs `gemma3:4b` vs `qwen3:1.7b`)
 - Bei subjektivem Eindruck "die Quellen sind schlecht" → konkrete Daten holen
 - Nach Threshold-Änderungen in `application.yml`
 - Beim Evaluieren neuer Query-Formulierungen
+
+### Sync mit dem Java-Reranker
+
+Das Script repliziert intern die Logik aus `LlmListwiseReranker.java`:
+- Gleicher Prompt-Aufbau (Listwise mit nummerierten Chunks)
+- Gleiche Truncation auf `MAX_CHUNK_CHARS`
+- Gleicher Regex-basierter JSON-Array-Parser
+- Gleiche Padding-Logik wenn der LLM weniger als `top_k` Indices liefert
+
+Wenn der Java-Code geändert wird, muss `_build_rerank_prompt` und `_parse_and_pad` im Script entsprechend angepasst werden. Die Tests in `LlmListwiseRerankerTest.java` sind die Quelle der Wahrheit für das erwartete Verhalten.
 
 ---
 

--- a/scripts/retrieval-quality-check.py
+++ b/scripts/retrieval-quality-check.py
@@ -3,26 +3,45 @@
 Retrieval-Quality Check
 
 Runs a configurable set of test queries against the ingested Qdrant
-collection and prints per-query scores + top matches. Useful for:
+collection and prints per-query top matches with scores. Supports three
+modes via the MODE env var:
 
+  - vector  : raw vector search only (the "before reranker" baseline)
+  - rerank  : top-K after LLM listwise rerank (the "after reranker" view)
+  - both    : side-by-side comparison with rank-change indicators (default)
+
+The rerank logic mirrors the Java LlmListwiseReranker — same prompt
+shape and same JSON-array parser. Keep them in sync if you change the
+production code.
+
+Useful for:
   - Comparing embedding models (e.g. nomic-embed-text vs bge-m3)
   - Evaluating threshold settings
   - Spot-checking retrieval quality after ingest changes
-  - Measuring the effect of reranker on/off (run app, compare output)
+  - Measuring before/after of the LLM reranker without restarting the app
+  - Trying different reranker models (qwen3:0.6b vs gemma3:4b vs ...)
 
 Prerequisites:
   - Ollama running on OLLAMA_URL with the embedding model loaded
   - Qdrant running on QDRANT_URL with the ingested collection
+  - For MODE=rerank or MODE=both: also the rerank LLM (default qwen3:0.6b)
   - App has been ingested at least once
 
 Usage:
-  # With defaults (localhost, bge-m3, confluence-chunks collection)
+  # Defaults: bge-m3 + qwen3:0.6b reranker, both modes side-by-side
   python3 scripts/retrieval-quality-check.py
 
-  # Override model / URLs / collection
+  # Vector-only baseline (skip rerank)
+  MODE=vector python3 scripts/retrieval-quality-check.py
+
+  # After-rerank only
+  MODE=rerank python3 scripts/retrieval-quality-check.py
+
+  # Different rerank model
+  RERANK_MODEL=gemma3:4b python3 scripts/retrieval-quality-check.py
+
+  # Different embedding model (compare against the old nomic-embed-text)
   EMBED_MODEL=nomic-embed-text python3 scripts/retrieval-quality-check.py
-  OLLAMA_URL=http://localhost:11434 QDRANT_URL=http://localhost:6333 \
-    COLLECTION=confluence-chunks python3 scripts/retrieval-quality-check.py
 
   # Ad-hoc single query
   python3 scripts/retrieval-quality-check.py "Wie funktioniert X?"
@@ -32,6 +51,7 @@ Edit the QUERIES list below to match your own content.
 
 import json
 import os
+import re
 import sys
 import urllib.request
 
@@ -39,7 +59,21 @@ OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434")
 QDRANT_URL = os.getenv("QDRANT_URL", "http://localhost:6333")
 COLLECTION = os.getenv("COLLECTION", "confluence-chunks")
 EMBED_MODEL = os.getenv("EMBED_MODEL", "bge-m3")
-TOP_K = int(os.getenv("TOP_K", "10"))
+TOP_K = int(os.getenv("TOP_K", "5"))
+MODE = os.getenv("MODE", "both")  # vector | rerank | both
+
+# Reranker config (mirrors LlmListwiseReranker defaults)
+RERANK_MODEL = os.getenv("RERANK_MODEL", "qwen3:0.6b")
+CANDIDATE_COUNT = int(os.getenv("CANDIDATE_COUNT", "15"))
+MAX_CHUNK_CHARS = int(os.getenv("MAX_CHUNK_CHARS", "500"))
+RERANK_TIMEOUT = int(os.getenv("RERANK_TIMEOUT", "60"))
+# num_predict needs to be high enough for "thinking" models like qwen3 to
+# emit their internal <think> block AND still produce the JSON array.
+NUM_PREDICT = int(os.getenv("NUM_PREDICT", "1024"))
+
+# Pattern to extract first JSON array of integers from any text — same
+# regex used in LlmListwiseReranker.parseJsonArray.
+JSON_ARRAY_PATTERN = re.compile(r"\[\s*\d+(?:\s*,\s*\d+)*\s*]")
 
 # (query_text, expected_top_match_hint)
 # Edit these to match your own corpus. The hint is just for human reading.
@@ -54,54 +88,219 @@ QUERIES = [
 ]
 
 
-def embed(text: str) -> list:
+# ---------- HTTP helpers ----------
+
+
+def _post_json(url: str, payload: dict, timeout: int = 30) -> dict:
     req = urllib.request.Request(
-        f"{OLLAMA_URL}/api/embed",
-        data=json.dumps({"model": EMBED_MODEL, "input": text}).encode(),
+        url,
+        data=json.dumps(payload).encode(),
         headers={"Content-Type": "application/json"},
     )
-    with urllib.request.urlopen(req) as r:
-        return json.loads(r.read())["embeddings"][0]
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return json.loads(r.read())
+
+
+def embed(text: str) -> list:
+    return _post_json(
+        f"{OLLAMA_URL}/api/embed",
+        {"model": EMBED_MODEL, "input": text},
+    )["embeddings"][0]
 
 
 def search(vector: list, top: int) -> list:
-    req = urllib.request.Request(
+    return _post_json(
         f"{QDRANT_URL}/collections/{COLLECTION}/points/search",
-        data=json.dumps({"vector": vector, "limit": top, "with_payload": True}).encode(),
-        headers={"Content-Type": "application/json"},
+        {"vector": vector, "limit": top, "with_payload": True},
+    )["result"]
+
+
+# ---------- Reranker (mirrors LlmListwiseReranker) ----------
+
+
+def llm_listwise_rerank(query: str, candidates: list, top_k: int) -> list:
+    """
+    Replicate the Java LlmListwiseReranker logic via direct Ollama API call.
+    Returns a list of candidate indices in new order, padded with original
+    order if the LLM returned fewer than top_k valid indices. Falls back
+    to original order on any error.
+    """
+    if not candidates:
+        return []
+    if len(candidates) <= top_k:
+        return list(range(len(candidates)))
+
+    try:
+        prompt = _build_rerank_prompt(query, candidates, top_k)
+        payload = {
+            "model": RERANK_MODEL,
+            "prompt": prompt,
+            "stream": False,
+            "options": {"temperature": 0, "top_p": 0.1, "num_predict": NUM_PREDICT},
+        }
+        resp = _post_json(f"{OLLAMA_URL}/api/generate", payload, timeout=RERANK_TIMEOUT)
+        response_text = resp.get("response", "")
+        return _parse_and_pad(response_text, len(candidates), top_k)
+    except Exception as e:
+        print(f"   ! Rerank fallback (Vektor-Reihenfolge): {e}", file=sys.stderr)
+        return list(range(top_k))
+
+
+def _build_rerank_prompt(query: str, candidates: list, top_k: int) -> str:
+    lines = [
+        "Du bist ein Such-Assistent. Bewerte die Relevanz folgender Dokument-Auszüge",
+        "für die Frage.",
+        "",
+        f'Frage: "{query}"',
+        "",
+        "Dokumente:",
+    ]
+    n = min(len(candidates), CANDIDATE_COUNT)
+    for i in range(n):
+        c = candidates[i]
+        payload = c.get("payload", {})
+        title = payload.get("pageTitle", "")
+        text = payload.get("doc_content", "") or ""
+        truncated = text[:MAX_CHUNK_CHARS] + ("..." if len(text) > MAX_CHUNK_CHARS else "")
+        lines.append(f"[{i + 1}] Titel: {title}")
+        lines.append(truncated)
+        lines.append("")
+    lines.extend(
+        [
+            f"Gib die Nummern der {top_k} relevantesten Dokumente in absteigender Relevanz",
+            "als JSON-Array zurück. Beispiel: [3, 7, 1, 12, 5]",
+            "",
+            "Antworte AUSSCHLIESSLICH mit dem Array. Keine Erklärung, kein Markdown,",
+            "keine Anführungszeichen drumherum. Nur das Array.",
+        ]
     )
-    with urllib.request.urlopen(req) as r:
-        return json.loads(r.read())["result"]
+    return "\n".join(lines)
+
+
+def _parse_and_pad(text: str, n_candidates: int, top_k: int) -> list:
+    """Parse first JSON array from text, dedupe, validate, pad with original order."""
+    indices: list = []
+    seen: set = set()
+    if text:
+        m = JSON_ARRAY_PATTERN.search(text)
+        if m:
+            inner = m.group()[1:-1]
+            for token in inner.split(","):
+                token = token.strip()
+                if not token:
+                    continue
+                try:
+                    idx = int(token) - 1  # convert from 1-based
+                except ValueError:
+                    continue
+                if 0 <= idx < n_candidates and idx not in seen:
+                    seen.add(idx)
+                    indices.append(idx)
+                if len(indices) >= top_k:
+                    break
+    # Pad with original-order candidates not yet used
+    if len(indices) < top_k:
+        for i in range(n_candidates):
+            if i not in seen and len(indices) < top_k:
+                indices.append(i)
+                seen.add(i)
+    return indices[:top_k]
+
+
+# ---------- Output ----------
+
+
+def _format_title(payload: dict) -> str:
+    title = payload.get("pageTitle", "?")
+    space = payload.get("spaceKey", "?")
+    return f"[{space}] {title[:70]}"
+
+
+def _print_vector_only(candidates: list, top_k: int) -> None:
+    shown = candidates[:top_k]
+    if not shown:
+        print("   (no hits)")
+        return
+    scores = [h["score"] for h in shown]
+    spread = scores[0] - scores[-1] if len(scores) > 1 else 0.0
+    print(f"   top1={scores[0]:.4f}  top{len(shown)}={scores[-1]:.4f}  spread={spread:.4f}")
+    for i, h in enumerate(shown):
+        print(f"   {i + 1:2}. {h['score']:.4f}  {_format_title(h.get('payload', {}))}")
+
+
+def _print_rerank_only(candidates: list, indices: list) -> None:
+    if not indices:
+        print("   (no hits)")
+        return
+    for new_pos, idx in enumerate(indices):
+        h = candidates[idx]
+        print(f"   {new_pos + 1:2}. {h['score']:.4f}  {_format_title(h.get('payload', {}))}")
+
+
+def _print_compare(candidates: list, indices: list, top_k: int) -> None:
+    """Side-by-side: vector top-K and reranked top-K with rank-change arrows."""
+    if not candidates:
+        print("   (no hits)")
+        return
+
+    print("\n   -- Vector-only --")
+    _print_vector_only(candidates, top_k)
+
+    print("\n   -- After LLM Listwise Rerank --")
+    if not indices:
+        print("   (no hits)")
+        return
+    for new_pos, idx in enumerate(indices):
+        h = candidates[idx]
+        old_pos = idx  # in vector order, position equals index
+        if old_pos < top_k:
+            if old_pos > new_pos:
+                arrow = f"↑ from #{old_pos + 1}"
+            elif old_pos < new_pos:
+                arrow = f"↓ from #{old_pos + 1}"
+            else:
+                arrow = "= unchanged"
+        else:
+            arrow = f"★ promoted (was #{old_pos + 1})"
+        title = _format_title(h.get("payload", {}))
+        print(f"   {new_pos + 1:2}. {h['score']:.4f}  {arrow:18s}  {title}")
 
 
 def run(query: str, expect: str = "") -> None:
     print(f"\n=== Query: {query!r}")
     if expect:
         print(f"    ({expect})")
+
+    fetch_k = max(TOP_K, CANDIDATE_COUNT) if MODE in ("rerank", "both") else TOP_K
     vector = embed(query)
-    hits = search(vector, TOP_K)
-    if not hits:
-        print("   (no hits)")
+    candidates = search(vector, fetch_k)
+
+    if MODE == "vector":
+        _print_vector_only(candidates, TOP_K)
         return
-    scores = [h["score"] for h in hits]
-    spread = scores[0] - scores[-1]
-    print(f"   top1={scores[0]:.4f}  top{TOP_K}={scores[-1]:.4f}  spread={spread:.4f}")
-    for i, h in enumerate(hits):
-        payload = h.get("payload", {})
-        title = payload.get("pageTitle", "?")
-        space = payload.get("spaceKey", "?")
-        print(f"   {i+1:2}. {h['score']:.4f}  [{space}] {title[:80]}")
+
+    indices = llm_listwise_rerank(query, candidates, TOP_K)
+
+    if MODE == "rerank":
+        _print_rerank_only(candidates, indices)
+        return
+
+    # default: both
+    _print_compare(candidates, indices, TOP_K)
 
 
 def main() -> None:
-    print(f"# retrieval-quality-check")
-    print(f"#   ollama:     {OLLAMA_URL}")
-    print(f"#   qdrant:     {QDRANT_URL}/{COLLECTION}")
-    print(f"#   embed:      {EMBED_MODEL}")
-    print(f"#   top_k:      {TOP_K}")
+    print("# retrieval-quality-check")
+    print(f"#   ollama:          {OLLAMA_URL}")
+    print(f"#   qdrant:          {QDRANT_URL}/{COLLECTION}")
+    print(f"#   embed:           {EMBED_MODEL}")
+    print(f"#   top_k:           {TOP_K}")
+    print(f"#   mode:            {MODE}")
+    if MODE in ("rerank", "both"):
+        print(f"#   rerank_model:    {RERANK_MODEL}")
+        print(f"#   candidate_count: {CANDIDATE_COUNT}")
 
     if len(sys.argv) > 1:
-        # Ad-hoc single query from CLI
         run(" ".join(sys.argv[1:]))
         return
 

--- a/src/main/java/at/openaustria/confluencerag/query/LlmListwiseReranker.java
+++ b/src/main/java/at/openaustria/confluencerag/query/LlmListwiseReranker.java
@@ -124,11 +124,16 @@ public class LlmListwiseReranker implements Reranker {
     }
 
     private String callOllama(String prompt) {
+        // num_predict must be high enough to allow "thinking" models like qwen3
+        // to emit their internal <think>...</think> block AND still produce the
+        // final JSON array. 64 tokens are eaten entirely by the thinking block
+        // on qwen3:0.6b, leaving the response empty. 1024 is comfortable for
+        // both thinking and non-thinking models.
         OllamaRequest req = new OllamaRequest(
                 config.model(),
                 prompt,
                 false,
-                new OllamaOptions(0.0, 0.1, 64));
+                new OllamaOptions(0.0, 0.1, 1024));
 
         OllamaResponse resp = restClient.post()
                 .uri("/api/generate")


### PR DESCRIPTION
## Summary
- `scripts/retrieval-quality-check.py` extended with three modes (`MODE=vector|rerank|both`, default `both`) for before/after comparison
- Side-by-side output with rank-change arrows (↑/↓/=/★ promoted)
- Replicates `LlmListwiseReranker` Java logic 1:1 (prompt + parser + padding) so no running app is needed
- New env vars: `MODE`, `RERANK_MODEL`, `CANDIDATE_COUNT`, `MAX_CHUNK_CHARS`, `RERANK_TIMEOUT`, `NUM_PREDICT`
- Bonus fix: bump `num_predict` from 64 to 1024 in `LlmListwiseReranker` so qwen3-style thinking models actually produce output

Closes #41

## Why
Discovered while testing the script: with `num_predict=64`, qwen3:0.6b's internal `<think>...</think>` block consumes the entire token budget and the actual JSON response is empty. The padding code then returns the original vector order, making the reranker silently a no-op. With `num_predict=1024` qwen3 has room for both the thinking block and the answer, and non-thinking models still stop early at EOS.

## Verified
Live test with qwen3:0.6b on the test corpus showing real rank changes:

| Query | Vector top-1 | After rerank | Effect |
|-------|--------------|--------------|--------|
| Admin API Endpunkte | Frontend-Panel | Backend-API | API-Doku #4 → #2 |
| Qdrant konfigurieren | docker-compose.yml | docker-compose.yml | Backup-Seite raus, 3 promoted |
| Backup und Recovery | Backup-Seite | Backup-Seite | top-1 stable, rest neu sortiert |
| Was ist CORS? | Spec 07 Akzeptanzkriterien | Spec 07 Akzeptanzkriterien | Issue #12 CORS #5 → #4 |
| PlantUML | Spec 03 | Spec 03 | unchanged (already optimal) |
| Spec 07 | Spec 07 | Spec 07 | unchanged (already optimal) |

## Test Plan
- [x] All 67 unit tests pass (Java change is config-only)
- [x] Script syntax check
- [x] Live: `MODE=both` shows side-by-side with rank changes
- [x] Live: `MODE=vector` skips rerank call
- [x] Live: `MODE=rerank` shows reranked only
- [x] Real reranker now produces non-trivial reorderings

🤖 Generated with [Claude Code](https://claude.com/claude-code)